### PR TITLE
fix(security): prevent dispute_resolver == platform self-dealing overlap — single-release (#109)

### DIFF
--- a/contracts/escrow/src/core/validators/escrow.rs
+++ b/contracts/escrow/src/core/validators/escrow.rs
@@ -129,6 +129,7 @@ fn validate_dispute_resolver_role_overlap(roles: &Roles) -> Result<(), EscrowErr
             || roles.service_providers.contains(&resolver)
             || roles.release_signers.contains(&resolver)
             || resolver == roles.receiver
+            || &resolver == &roles.platform
         {
             return Err(EscrowError::DisputeResolverOverlapsWithOtherRole);
         }

--- a/contracts/escrow/src/core/validators/escrow.rs
+++ b/contracts/escrow/src/core/validators/escrow.rs
@@ -129,7 +129,7 @@ fn validate_dispute_resolver_role_overlap(roles: &Roles) -> Result<(), EscrowErr
             || roles.service_providers.contains(&resolver)
             || roles.release_signers.contains(&resolver)
             || resolver == roles.receiver
-            || &resolver == &roles.platform
+            || resolver == roles.platform
         {
             return Err(EscrowError::DisputeResolverOverlapsWithOtherRole);
         }

--- a/contracts/escrow/src/tests/escrow.rs
+++ b/contracts/escrow/src/tests/escrow.rs
@@ -875,8 +875,8 @@ fn test_dispute_resolver_cannot_equal_platform() {
     let test_data = create_escrow_contract(&env, &escrow_admin);
     let res = test_data.client.try_initialize_escrow(&escrow);
     assert!(
-        res.is_err(),
-        "dispute_resolver == platform must be rejected"
+        matches!(res, Err(Ok(EscrowError::DisputeResolverOverlapsWithOtherRole))),
+        "dispute_resolver == platform must be rejected with DisputeResolverOverlapsWithOtherRole"
     );
 
     // distinct dispute_resolver and platform must succeed

--- a/contracts/escrow/src/tests/escrow.rs
+++ b/contracts/escrow/src/tests/escrow.rs
@@ -878,4 +878,39 @@ fn test_dispute_resolver_cannot_equal_platform() {
         res.is_err(),
         "dispute_resolver == platform must be rejected"
     );
+
+    // distinct dispute_resolver and platform must succeed
+    let distinct_dispute_resolver = Address::generate(&env);
+    let escrow_valid = Escrow {
+        engagement_id: String::from_str(&env, "platform_resolver_distinct"),
+        title: String::from_str(&env, "Test"),
+        description: String::from_str(&env, "Test"),
+        roles: Roles {
+            approvers: vec![&env, approver.clone()],
+            service_providers: vec![&env, service_provider.clone()],
+            platform: shared_address.clone(), // different from dispute_resolver
+            release_signers: vec![&env, release_signer.clone()],
+            dispute_resolvers: vec![&env, distinct_dispute_resolver], // different from platform
+            receiver: receiver.clone(),
+            admin: escrow_admin.clone(),
+            observers: vec![&env],
+        },
+        amount: 100_000_000,
+        platform_fee: 0,
+        milestones: vec![&env],
+        dispute: Dispute {
+            is_disputed: false,
+            reason: String::from_str(&env, ""),
+            resolved: false,
+        },
+        released: false,
+        trustline: Trustline {
+            address: usdc_token.0.address.clone(),
+        },
+        receiver_memo: 0,
+    };
+
+    let test_data = create_escrow_contract(&env, &escrow_admin);
+    let res = test_data.client.try_initialize_escrow(&escrow_valid);
+    assert!(res.is_ok(), "Non-overlapping platform and dispute_resolver must succeed");
 }

--- a/contracts/escrow/src/tests/escrow.rs
+++ b/contracts/escrow/src/tests/escrow.rs
@@ -1,5 +1,6 @@
 extern crate std;
 
+use crate::error::EscrowError;
 use crate::storage::types::{Dispute, Escrow, Milestone, MilestoneApprovals, Roles, Trustline};
 use soroban_sdk::{testutils::Address as _, vec, Address, Env, String};
 

--- a/contracts/escrow/src/tests/escrow.rs
+++ b/contracts/escrow/src/tests/escrow.rs
@@ -826,3 +826,56 @@ fn test_initialize_escrow_without_milestones() {
     let escrow = test_data.client.get_escrow();
     assert!(escrow.milestones.is_empty());
 }
+
+#[test]
+fn test_dispute_resolver_cannot_equal_platform() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let escrow_admin = Address::generate(&env);
+    let shared_address = Address::generate(&env); // will be both platform and dispute_resolver
+    let approver = Address::generate(&env);
+    let service_provider = Address::generate(&env);
+    let release_signer = Address::generate(&env);
+    let receiver = Address::generate(&env); // distinct from platform
+
+    let usdc_token = create_usdc_token(&env, &admin);
+
+    let escrow = Escrow {
+        engagement_id: String::from_str(&env, "platform_resolver_overlap"),
+        title: String::from_str(&env, "Test"),
+        description: String::from_str(&env, "Test"),
+        roles: Roles {
+            approvers: vec![&env, approver.clone()],
+            service_providers: vec![&env, service_provider.clone()],
+            platform: shared_address.clone(), // same as dispute_resolver
+            release_signers: vec![&env, release_signer.clone()],
+            dispute_resolvers: vec![&env, shared_address.clone()], // same as platform
+            receiver: receiver.clone(), // distinct
+            admin: escrow_admin.clone(),
+            observers: vec![&env],
+        },
+        amount: 100_000_000,
+        platform_fee: 0,
+        milestones: vec![&env],
+        dispute: Dispute {
+            is_disputed: false,
+            reason: String::from_str(&env, ""),
+            resolved: false,
+        },
+        released: false,
+        trustline: Trustline {
+            address: usdc_token.0.address.clone(),
+        },
+        receiver_memo: 0,
+    };
+
+    // dispute_resolver == platform must fail
+    let test_data = create_escrow_contract(&env, &escrow_admin);
+    let res = test_data.client.try_initialize_escrow(&escrow);
+    assert!(
+        res.is_err(),
+        "dispute_resolver == platform must be rejected"
+    );
+}

--- a/contracts/escrow/test_snapshots/modules/fee/distribution/tests/rejects_zero_total.1.json
+++ b/contracts/escrow/test_snapshots/modules/fee/distribution/tests/rejects_zero_total.1.json
@@ -1,0 +1,213 @@
+{
+  "generators": {
+    "address": 5,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CBEPDNVYXQGWB5YUBXKJWYJA7OXTZW5LFLNO5JRRGE6Z6C5OSUZPCCEL",
+              "function_name": "set_admin",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ]
+  ],
+  "ledger": {
+    "protocol_version": 26,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "account": {
+              "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF",
+              "balance": "0",
+              "seq_num": "0",
+              "num_sub_entries": 0,
+              "inflation_dest": null,
+              "flags": 0,
+              "home_domain": "",
+              "thresholds": "01010101",
+              "signers": [],
+              "ext": "v0"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": null
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CBEPDNVYXQGWB5YUBXKJWYJA7OXTZW5LFLNO5JRRGE6Z6C5OSUZPCCEL",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": "stellar_asset",
+                  "storage": [
+                    {
+                      "key": {
+                        "symbol": "METADATA"
+                      },
+                      "val": {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "decimal"
+                            },
+                            "val": {
+                              "u32": 7
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "name"
+                            },
+                            "val": {
+                              "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "symbol"
+                            },
+                            "val": {
+                              "string": "aaa"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "Admin"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "AssetInfo"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "AlphaNum4"
+                          },
+                          {
+                            "map": [
+                              {
+                                "key": {
+                                  "symbol": "asset_code"
+                                },
+                                "val": {
+                                  "string": "aaa\\0"
+                                }
+                              },
+                              {
+                                "key": {
+                                  "symbol": "issuer"
+                                },
+                                "val": {
+                                  "bytes": "0000000000000000000000000000000000000000000000000000000000000002"
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 120960
+      }
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "CBEPDNVYXQGWB5YUBXKJWYJA7OXTZW5LFLNO5JRRGE6Z6C5OSUZPCCEL",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "set_admin"
+              },
+              {
+                "address": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF"
+              },
+              {
+                "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF"
+              }
+            ],
+            "data": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}


### PR DESCRIPTION
Closes #109

## Problem
`validate_dispute_resolver_role_overlap` checked approvers, service_providers,
release_signers, and receiver — but not `platform`. A single address could be both
`dispute_resolver` and `platform`, letting it decide arbitrary fund distributions
while also collecting the platform fee.

## Fix
One added condition in the existing `if`:

```rust
|| &resolver == &roles.platform
```

Error type unchanged: `DisputeResolverOverlapsWithOtherRole`.
Existing receiver check preserved.

## Tests
- Added: `test_dispute_resolver_cannot_equal_platform` — asserts initialization
  is rejected when `dispute_resolver == platform`
- All existing role-overlap tests pass (46/46 tests passed)

## Branch
single-release-develop-v2

## Companion PR
- Multi-release PR: #111