### PR TITLE
fix(audit trail): events omit changed values, weakening on-chain traceability

### DIFF
--- a/contracts/escrow/src/contract.rs
+++ b/contracts/escrow/src/contract.rs
@@ -1,3 +1,4 @@
+use soroban_sdk::xdr::ToXdr;
 use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, Map, String, Symbol, Val, Vec};
 
 use crate::core::{DisputeManager, EscrowManager, MilestoneManager};
@@ -132,11 +133,14 @@ impl EscrowContract {
         admin_address: Address,
         escrow_properties: Escrow,
     ) -> Result<Escrow, EscrowError> {
+        let existing_escrow = EscrowManager::get_escrow(e).ok();
         let updated_escrow =
             EscrowManager::change_escrow_properties(e, &admin_address, escrow_properties)?;
+        let changed_fields = diff_escrow_fields(e, existing_escrow.as_ref(), &updated_escrow);
         EscrowUpdated {
             engagement_id: updated_escrow.engagement_id.clone(),
             admin: admin_address,
+            changed_fields,
         }
         .publish(e);
         Ok(updated_escrow)
@@ -150,6 +154,14 @@ impl EscrowContract {
     ) -> Result<Escrow, EscrowError> {
         let added_count = new_milestones.len();
         let updated_count = milestone_updates.len();
+        let mut updated_indices: Vec<u32> = Vec::new(e);
+        for update in milestone_updates.iter() {
+            updated_indices.push_back(update.index);
+        }
+        let mut added_description_hashes: Vec<BytesN<32>> = Vec::new(e);
+        for milestone in new_milestones.iter() {
+            added_description_hashes.push_back(hash_string(e, &milestone.description));
+        }
         let updated_escrow =
             EscrowManager::manage_milestones(e, &admin_address, new_milestones, milestone_updates)?;
         MilestonesManaged {
@@ -157,6 +169,8 @@ impl EscrowContract {
             admin: admin_address,
             added_count,
             updated_count,
+            updated_indices,
+            added_description_hashes,
         }
         .publish(e);
         Ok(updated_escrow)
@@ -234,9 +248,11 @@ impl EscrowContract {
     ) -> Result<(), MilestoneError> {
         let mut status_entries: Vec<MilestoneStatusEntry> = Vec::new(&e);
         for update in updates.iter() {
+            let evidence_hash = update.new_evidence.as_ref().map(|ev| hash_string(&e, ev));
             status_entries.push_back(MilestoneStatusEntry {
                 index: update.milestone_index,
                 status: update.new_status.clone(),
+                evidence_hash,
             });
         }
         let escrow =
@@ -387,4 +403,56 @@ impl EscrowContract {
         .publish(&e);
         Ok(())
     }
+}
+
+/// sha256 of a contract `String`'s XDR encoding — used to prove which value
+/// was submitted (evidence, a description) in an event without echoing the
+/// full text, which could be arbitrarily long.
+fn hash_string(e: &Env, value: &String) -> BytesN<32> {
+    e.crypto().sha256(&value.to_xdr(e)).to_bytes()
+}
+
+/// Names of the top-level `Escrow` fields that differ between `before` and
+/// `after`. `before` is `None` when the prior escrow couldn't be read (should
+/// not happen in practice, since `update_escrow` only replaces an existing
+/// escrow) — in that case every field is reported changed rather than
+/// silently reporting none, since "no evidence of a diff" is not the same
+/// claim as "nothing changed."
+fn diff_escrow_fields(e: &Env, before: Option<&Escrow>, after: &Escrow) -> Vec<String> {
+    let mut changed: Vec<String> = Vec::new(e);
+    let before = match before {
+        Some(b) => b,
+        None => {
+            changed.push_back(String::from_str(e, "title"));
+            changed.push_back(String::from_str(e, "description"));
+            changed.push_back(String::from_str(e, "platform_fee"));
+            changed.push_back(String::from_str(e, "milestones"));
+            changed.push_back(String::from_str(e, "trustline"));
+            changed.push_back(String::from_str(e, "receiver_memo"));
+            changed.push_back(String::from_str(e, "roles"));
+            return changed;
+        }
+    };
+    if before.title != after.title {
+        changed.push_back(String::from_str(e, "title"));
+    }
+    if before.description != after.description {
+        changed.push_back(String::from_str(e, "description"));
+    }
+    if before.platform_fee != after.platform_fee {
+        changed.push_back(String::from_str(e, "platform_fee"));
+    }
+    if before.milestones != after.milestones {
+        changed.push_back(String::from_str(e, "milestones"));
+    }
+    if before.trustline != after.trustline {
+        changed.push_back(String::from_str(e, "trustline"));
+    }
+    if before.receiver_memo != after.receiver_memo {
+        changed.push_back(String::from_str(e, "receiver_memo"));
+    }
+    if before.roles != after.roles {
+        changed.push_back(String::from_str(e, "roles"));
+    }
+    changed
 }

--- a/contracts/escrow/src/events/handler.rs
+++ b/contracts/escrow/src/events/handler.rs
@@ -1,5 +1,5 @@
 use crate::storage::types::{DistributionEntry, MilestonePayout, MilestoneStatusEntry};
-use soroban_sdk::{contractevent, Address, String, Vec};
+use soroban_sdk::{contractevent, Address, BytesN, String, Vec};
 
 #[contractevent(topics = ["tw_init"])]
 #[derive(Clone)]
@@ -35,6 +35,9 @@ pub struct EscrowUpdated {
     #[topic]
     pub engagement_id: String,
     pub admin: Address,
+    /// Names of the top-level Escrow fields whose value changed. Empty when
+    /// the update stored an escrow identical to the one it replaced.
+    pub changed_fields: Vec<String>,
 }
 
 #[contractevent(topics = ["tw_ms_change"])]
@@ -96,6 +99,11 @@ pub struct MilestonesManaged {
     pub admin: Address,
     pub added_count: u32,
     pub updated_count: u32,
+    /// Indices of the existing milestones that were updated, in call order.
+    pub updated_indices: Vec<u32>,
+    /// sha256 of each newly added milestone's description, in append order —
+    /// hashed rather than echoed to keep the event small.
+    pub added_description_hashes: Vec<BytesN<32>>,
 }
 
 #[contractevent(topics = ["tw_ttl_extend"])]

--- a/contracts/escrow/src/storage/types.rs
+++ b/contracts/escrow/src/storage/types.rs
@@ -1,10 +1,14 @@
-use soroban_sdk::{contracttype, Address, String, Vec};
+use soroban_sdk::{contracttype, Address, BytesN, String, Vec};
 
 #[contracttype]
 #[derive(Clone)]
 pub struct MilestoneStatusEntry {
     pub index: u32,
     pub status: String,
+    /// sha256 of the new evidence string, when this update carries one.
+    /// Hashed rather than echoed to keep the event small while still
+    /// letting an off-chain indexer prove which evidence was submitted.
+    pub evidence_hash: Option<BytesN<32>>,
 }
 
 #[contracttype]

--- a/contracts/escrow/src/tests/escrow.rs
+++ b/contracts/escrow/src/tests/escrow.rs
@@ -1,8 +1,9 @@
 extern crate std;
 
 use crate::error::{EscrowError, ReleaseError};
+use crate::events::handler::EscrowUpdated;
 use crate::storage::types::{Dispute, Escrow, Milestone, MilestoneApprovals, Roles, Trustline};
-use soroban_sdk::{testutils::Address as _, vec, Address, Env, String};
+use soroban_sdk::{testutils::Address as _, testutils::Events as _, vec, Address, Env, Event as _, String};
 
 use super::helpers::{create_escrow_contract, create_usdc_token};
 
@@ -1037,4 +1038,104 @@ fn test_dispute_resolver_cannot_equal_platform() {
     let test_data = create_escrow_contract(&env, &escrow_admin);
     let res = test_data.client.try_initialize_escrow(&escrow_valid);
     assert!(res.is_ok(), "Non-overlapping platform and dispute_resolver must succeed");
+}
+
+#[test]
+fn test_update_escrow_event_reports_changed_fields() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let escrow_admin = Address::generate(&env);
+    let approver = Address::generate(&env);
+    let service_provider = Address::generate(&env);
+    let release_signer = Address::generate(&env);
+    let dispute_resolver = Address::generate(&env);
+    let receiver = Address::generate(&env);
+    let platform = Address::generate(&env);
+
+    let usdc_token = create_usdc_token(&env, &admin);
+
+    let milestones = vec![
+        &env,
+        Milestone {
+            description: String::from_str(&env, "Milestone 1"),
+            status: String::from_str(&env, "Pending"),
+            evidence: String::from_str(&env, ""),
+            approvals: MilestoneApprovals {
+                target: 1,
+                approval_count: 0,
+                approved_by: vec![&env],
+            },
+            amount: 100_000_000,
+            dispute: Dispute {
+                is_disputed: false,
+                reason: String::from_str(&env, ""),
+                resolved: false,
+            },
+            released: false,
+            receiver: receiver.clone(),
+        },
+    ];
+
+    let roles = Roles {
+        approvers: vec![&env, approver.clone()],
+        service_providers: vec![&env, service_provider.clone()],
+        platform: platform.clone(),
+        release_signers: vec![&env, release_signer.clone()],
+        dispute_resolvers: vec![&env, dispute_resolver.clone()],
+        admin: escrow_admin.clone(),
+        observers: vec![&env],
+    };
+
+    let trustline = Trustline {
+        address: usdc_token.0.address.clone(),
+    };
+
+    let engagement_id = String::from_str(&env, "update_escrow_event_test");
+    let initial_escrow = Escrow {
+        engagement_id: engagement_id.clone(),
+        title: String::from_str(&env, "Original Title"),
+        description: String::from_str(&env, "Original Description"),
+        roles: roles.clone(),
+        platform_fee: 300,
+        milestones: milestones.clone(),
+        trustline: trustline.clone(),
+        receiver_memo: 0,
+    };
+
+    let test_data = create_escrow_contract(&env, &escrow_admin);
+    let client = test_data.client;
+    client.initialize_escrow(&initial_escrow);
+
+    // Only title and description change; everything else is passed back
+    // unchanged (milestones/roles/trustline/platform_fee/receiver_memo).
+    let updated_escrow = Escrow {
+        engagement_id: engagement_id.clone(),
+        title: String::from_str(&env, "New Title"),
+        description: String::from_str(&env, "New Description"),
+        roles: roles.clone(),
+        platform_fee: 300,
+        milestones: milestones.clone(),
+        trustline: trustline.clone(),
+        receiver_memo: 0,
+    };
+
+    client.update_escrow(&escrow_admin, &updated_escrow);
+
+    let expected_event = EscrowUpdated {
+        engagement_id: engagement_id.clone(),
+        admin: escrow_admin.clone(),
+        changed_fields: vec![
+            &env,
+            String::from_str(&env, "title"),
+            String::from_str(&env, "description"),
+        ],
+    };
+
+    assert_eq!(
+        env.events().all(),
+        std::vec![expected_event.to_xdr(&env, &client.address)],
+        "EscrowUpdated should report exactly the fields that changed, in field-declaration order"
+    );
 }

--- a/contracts/escrow/src/tests/milestone.rs
+++ b/contracts/escrow/src/tests/milestone.rs
@@ -1,10 +1,15 @@
 extern crate std;
 
 use crate::storage::types::{
-    Dispute, Escrow, Milestone, MilestoneApprovals, MilestoneStatusUpdate, MilestoneUpdate, Roles,
-    Trustline,
+    Dispute, Escrow, Milestone, MilestoneApprovals, MilestoneStatusEntry, MilestoneStatusUpdate,
+    MilestoneUpdate, Roles, Trustline,
 };
-use soroban_sdk::{testutils::Address as _, vec, Address, Env, String};
+use soroban_sdk::{
+    testutils::Address as _, testutils::Events as _, vec, xdr::ToXdr, Address, BytesN, Env,
+    Event as _, String,
+};
+
+use crate::events::handler::{MilestoneStatusChanged, MilestonesManaged};
 
 use super::helpers::{create_escrow_contract, create_usdc_token};
 
@@ -1703,4 +1708,244 @@ fn test_manage_milestones_rejects_non_positive_amount_update() {
 
     // Original amount unchanged.
     assert_eq!(client.get_escrow().milestones.get(0).unwrap().amount, 50_000_000);
+}
+
+#[test]
+fn test_manage_milestones_event_carries_indices_and_hashes() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let escrow_admin = Address::generate(&env);
+    let approver = Address::generate(&env);
+    let service_provider = Address::generate(&env);
+    let platform = Address::generate(&env);
+    let release_signer = Address::generate(&env);
+    let dispute_resolver = Address::generate(&env);
+    let receiver = Address::generate(&env);
+
+    let (token_client, _token_admin) = create_usdc_token(&env, &admin);
+
+    let m1_description = String::from_str(&env, "Milestone 1");
+    let initial_milestones = vec![
+        &env,
+        Milestone {
+            description: m1_description.clone(),
+            status: String::from_str(&env, "Pending"),
+            evidence: String::from_str(&env, ""),
+            approvals: MilestoneApprovals {
+                target: 1,
+                approval_count: 0,
+                approved_by: vec![&env],
+            },
+            amount: 50_000_000,
+            dispute: Dispute {
+                is_disputed: false,
+                reason: String::from_str(&env, ""),
+                resolved: false,
+            },
+            released: false,
+            receiver: receiver.clone(),
+        },
+    ];
+
+    let escrow_base = Escrow {
+        engagement_id: String::from_str(&env, "manage_milestones_event_test"),
+        title: String::from_str(&env, "Test"),
+        description: String::from_str(&env, "Desc"),
+        roles: Roles {
+            approvers: vec![&env, approver.clone()],
+            service_providers: vec![&env, service_provider.clone()],
+            platform: platform.clone(),
+            release_signers: vec![&env, release_signer.clone()],
+            dispute_resolvers: vec![&env, dispute_resolver.clone()],
+            admin: escrow_admin.clone(),
+            observers: vec![&env],
+        },
+        platform_fee: 300,
+        milestones: initial_milestones.clone(),
+        trustline: Trustline {
+            address: token_client.address.clone(),
+        },
+        receiver_memo: 0,
+    };
+
+    let test_data = create_escrow_contract(&env, &escrow_admin);
+    let client = test_data.client;
+    client.initialize_escrow(&escrow_base);
+
+    let new_description = String::from_str(&env, "Milestone 2");
+    let to_add = vec![
+        &env,
+        Milestone {
+            description: new_description.clone(),
+            status: String::from_str(&env, "Pending"),
+            evidence: String::from_str(&env, ""),
+            approvals: MilestoneApprovals {
+                target: 1,
+                approval_count: 0,
+                approved_by: vec![&env],
+            },
+            amount: 25_000_000,
+            dispute: Dispute {
+                is_disputed: false,
+                reason: String::from_str(&env, ""),
+                resolved: false,
+            },
+            released: false,
+            receiver: receiver.clone(),
+        },
+    ];
+    let updates = vec![
+        &env,
+        MilestoneUpdate {
+            index: 0,
+            new_description: None,
+            new_amount: Some(60_000_000),
+        },
+    ];
+
+    client.manage_milestones(&escrow_admin, &to_add, &updates);
+
+    let expected_hash: BytesN<32> = env.crypto().sha256(&new_description.to_xdr(&env)).to_bytes();
+    let expected_event = MilestonesManaged {
+        engagement_id: escrow_base.engagement_id.clone(),
+        admin: escrow_admin.clone(),
+        added_count: 1,
+        updated_count: 1,
+        updated_indices: vec![&env, 0u32],
+        added_description_hashes: vec![&env, expected_hash],
+    };
+
+    assert_eq!(
+        env.events().all(),
+        std::vec![expected_event.to_xdr(&env, &client.address)],
+        "emitted MilestonesManaged event did not carry the expected indices/hashes"
+    );
+}
+
+#[test]
+fn test_change_milestone_status_event_carries_evidence_hash() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let escrow_admin = Address::generate(&env);
+    let approver = Address::generate(&env);
+    let service_provider = Address::generate(&env);
+    let platform = Address::generate(&env);
+    let release_signer = Address::generate(&env);
+    let dispute_resolver = Address::generate(&env);
+    let receiver = Address::generate(&env);
+
+    let (token_client, _token_admin) = create_usdc_token(&env, &admin);
+
+    let initial_milestones = vec![
+        &env,
+        Milestone {
+            description: String::from_str(&env, "Milestone 1"),
+            status: String::from_str(&env, "in-progress"),
+            evidence: String::from_str(&env, "Initial evidence"),
+            approvals: MilestoneApprovals {
+                target: 1,
+                approval_count: 0,
+                approved_by: vec![&env],
+            },
+            amount: 100_000_000,
+            dispute: Dispute {
+                is_disputed: false,
+                reason: String::from_str(&env, ""),
+                resolved: false,
+            },
+            released: false,
+            receiver: receiver.clone(),
+        },
+        Milestone {
+            description: String::from_str(&env, "Milestone 2"),
+            status: String::from_str(&env, "in-progress"),
+            evidence: String::from_str(&env, "Initial evidence"),
+            approvals: MilestoneApprovals {
+                target: 1,
+                approval_count: 0,
+                approved_by: vec![&env],
+            },
+            amount: 100_000_000,
+            dispute: Dispute {
+                is_disputed: false,
+                reason: String::from_str(&env, ""),
+                resolved: false,
+            },
+            released: false,
+            receiver: receiver.clone(),
+        },
+    ];
+
+    let escrow_properties = Escrow {
+        engagement_id: String::from_str(&env, "evidence_hash_test"),
+        title: String::from_str(&env, "Test"),
+        description: String::from_str(&env, "Desc"),
+        roles: Roles {
+            approvers: vec![&env, approver.clone()],
+            service_providers: vec![&env, service_provider.clone()],
+            platform: platform.clone(),
+            release_signers: vec![&env, release_signer.clone()],
+            dispute_resolvers: vec![&env, dispute_resolver.clone()],
+            admin: escrow_admin.clone(),
+            observers: vec![&env],
+        },
+        platform_fee: 300,
+        milestones: initial_milestones,
+        trustline: Trustline {
+            address: token_client.address.clone(),
+        },
+        receiver_memo: 0,
+    };
+
+    let test_data = create_escrow_contract(&env, &escrow_admin);
+    let client = test_data.client;
+    client.initialize_escrow(&escrow_properties);
+
+    // One update carries new evidence, the other doesn't — the event must
+    // distinguish the two rather than hashing an absent value.
+    let new_evidence = String::from_str(&env, "Proof of delivery");
+    let updates = vec![
+        &env,
+        MilestoneStatusUpdate {
+            milestone_index: 0,
+            new_status: String::from_str(&env, "completed"),
+            new_evidence: Some(new_evidence.clone()),
+        },
+        MilestoneStatusUpdate {
+            milestone_index: 1,
+            new_status: String::from_str(&env, "completed"),
+            new_evidence: None,
+        },
+    ];
+
+    client.change_milestone_status(&updates, &service_provider);
+
+    let expected_hash: BytesN<32> = env.crypto().sha256(&new_evidence.to_xdr(&env)).to_bytes();
+    let expected_event = MilestoneStatusChanged {
+        engagement_id: escrow_properties.engagement_id.clone(),
+        service_provider: service_provider.clone(),
+        updates: vec![
+            &env,
+            MilestoneStatusEntry {
+                index: 0,
+                status: String::from_str(&env, "completed"),
+                evidence_hash: Some(expected_hash),
+            },
+            MilestoneStatusEntry {
+                index: 1,
+                status: String::from_str(&env, "completed"),
+                evidence_hash: None,
+            },
+        ],
+    };
+
+    assert_eq!(
+        env.events().all(),
+        std::vec![expected_event.to_xdr(&env, &client.address)],
+        "MilestoneStatusChanged should hash evidence when present and report None when absent"
+    );
 }


### PR DESCRIPTION
Fixes #110.

## What was wrong

An events-only indexer couldn't reconstruct *what* changed from these three events — they proved *that* something happened, not *what*:
- `EscrowUpdated` named the admin but not which properties changed (e.g. a `platform_fee` change before funding was invisible).
- `MilestoneStatusChanged`'s `MilestoneStatusEntry` carried `status` but not the updated `evidence`.
- `MilestonesManaged` reported counts but not which milestones were added/updated.

## What changed

- `EscrowUpdated` gains `changed_fields: Vec<String>` — the names of the top-level `Escrow` fields that differ between the escrow being replaced and the one replacing it. Computed by reading the existing escrow before `change_escrow_properties` runs, then comparing field-by-field against the result (`Escrow` already derives `PartialEq`).
- `MilestonesManaged` gains `updated_indices: Vec<u32>` (from the update batch, straightforward) and `added_description_hashes: Vec<BytesN<32>>` (sha256 of each newly added milestone's description, in append order).
- `MilestoneStatusEntry` (used inside `MilestoneStatusChanged`) gains `evidence_hash: Option<BytesN<32>>` — `Some(hash)` when a status update carries `new_evidence`, `None` when it doesn't.

Per the issue's hint, long free-text (evidence, description) is hashed rather than echoed to keep events small while still letting an indexer prove which content was submitted against the hash later. No existing event field was removed or changed — additive only.

## Testing

68 existing tests unaffected. Added 3 new tests, each asserting the *exact* emitted event payload via `Event::to_xdr(&env, &contract_id)` compared against `env.events().all()` (the pattern documented for this kind of assertion), not just checking the escrow's resulting stored state:
- `test_update_escrow_event_reports_changed_fields`
- `test_manage_milestones_event_carries_indices_and_hashes`
- `test_change_milestone_status_event_carries_evidence_hash` (covers both the with-evidence and without-evidence case in one batch, to prove the `None` path isn't silently hashing an absent value)

71/71 total. `cargo clippy --all-targets` shows no new warnings from the changed files (verified by diffing warning locations against a pre-change baseline).

Companion PR for `single-release-develop-v2` (same fix, adapted for that branch's `Escrow` shape where `amount`/`dispute`/`released` live at the escrow level rather than per-milestone) coming right after this one, per the issue's note that it applies to both branches.