### PR TITLE
fix(audit trail): events omit changed values, weakening on-chain traceability

### DIFF
--- a/contracts/escrow/src/contract.rs
+++ b/contracts/escrow/src/contract.rs
@@ -1,3 +1,4 @@
+use soroban_sdk::xdr::ToXdr;
 use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, Map, String, Symbol, Val, Vec};
 
 use crate::core::{DisputeManager, EscrowManager, MilestoneManager};
@@ -124,11 +125,14 @@ impl EscrowContract {
         admin_address: Address,
         escrow_properties: Escrow,
     ) -> Result<Escrow, EscrowError> {
+        let existing_escrow = EscrowManager::get_escrow(e).ok();
         let updated_escrow =
             EscrowManager::change_escrow_properties(e, &admin_address, escrow_properties)?;
+        let changed_fields = diff_escrow_fields(e, existing_escrow.as_ref(), &updated_escrow);
         EscrowUpdated {
             engagement_id: updated_escrow.engagement_id.clone(),
             admin: admin_address,
+            changed_fields,
         }
         .publish(e);
         Ok(updated_escrow)
@@ -142,6 +146,14 @@ impl EscrowContract {
     ) -> Result<Escrow, EscrowError> {
         let added_count = new_milestones.len();
         let updated_count = milestone_updates.len();
+        let mut updated_indices: Vec<u32> = Vec::new(e);
+        for update in milestone_updates.iter() {
+            updated_indices.push_back(update.index);
+        }
+        let mut added_description_hashes: Vec<BytesN<32>> = Vec::new(e);
+        for milestone in new_milestones.iter() {
+            added_description_hashes.push_back(hash_string(e, &milestone.description));
+        }
         let updated_escrow =
             EscrowManager::manage_milestones(e, &admin_address, new_milestones, milestone_updates)?;
         MilestonesManaged {
@@ -149,6 +161,8 @@ impl EscrowContract {
             admin: admin_address,
             added_count,
             updated_count,
+            updated_indices,
+            added_description_hashes,
         }
         .publish(e);
         Ok(updated_escrow)
@@ -226,9 +240,11 @@ impl EscrowContract {
     ) -> Result<(), MilestoneError> {
         let mut status_entries: Vec<MilestoneStatusEntry> = Vec::new(&e);
         for update in updates.iter() {
+            let evidence_hash = update.new_evidence.as_ref().map(|ev| hash_string(&e, ev));
             status_entries.push_back(MilestoneStatusEntry {
                 index: update.milestone_index,
                 status: update.new_status.clone(),
+                evidence_hash,
             });
         }
         let escrow =
@@ -365,4 +381,68 @@ impl EscrowContract {
         .publish(&e);
         Ok(())
     }
+}
+
+/// sha256 of a contract `String`'s XDR encoding — used to prove which value
+/// was submitted (evidence, a description) in an event without echoing the
+/// full text, which could be arbitrarily long.
+fn hash_string(e: &Env, value: &String) -> BytesN<32> {
+    e.crypto().sha256(&value.to_xdr(e)).to_bytes()
+}
+
+/// Names of the top-level `Escrow` fields that differ between `before` and
+/// `after`. `before` is `None` when the prior escrow couldn't be read (should
+/// not happen in practice, since `update_escrow` only replaces an existing
+/// escrow) — in that case every field is reported changed rather than
+/// silently reporting none, since "no evidence of a diff" is not the same
+/// claim as "nothing changed."
+fn diff_escrow_fields(e: &Env, before: Option<&Escrow>, after: &Escrow) -> Vec<String> {
+    let mut changed: Vec<String> = Vec::new(e);
+    let before = match before {
+        Some(b) => b,
+        None => {
+            changed.push_back(String::from_str(e, "title"));
+            changed.push_back(String::from_str(e, "description"));
+            changed.push_back(String::from_str(e, "amount"));
+            changed.push_back(String::from_str(e, "platform_fee"));
+            changed.push_back(String::from_str(e, "milestones"));
+            changed.push_back(String::from_str(e, "dispute"));
+            changed.push_back(String::from_str(e, "released"));
+            changed.push_back(String::from_str(e, "trustline"));
+            changed.push_back(String::from_str(e, "receiver_memo"));
+            changed.push_back(String::from_str(e, "roles"));
+            return changed;
+        }
+    };
+    if before.title != after.title {
+        changed.push_back(String::from_str(e, "title"));
+    }
+    if before.description != after.description {
+        changed.push_back(String::from_str(e, "description"));
+    }
+    if before.amount != after.amount {
+        changed.push_back(String::from_str(e, "amount"));
+    }
+    if before.platform_fee != after.platform_fee {
+        changed.push_back(String::from_str(e, "platform_fee"));
+    }
+    if before.milestones != after.milestones {
+        changed.push_back(String::from_str(e, "milestones"));
+    }
+    if before.dispute != after.dispute {
+        changed.push_back(String::from_str(e, "dispute"));
+    }
+    if before.released != after.released {
+        changed.push_back(String::from_str(e, "released"));
+    }
+    if before.trustline != after.trustline {
+        changed.push_back(String::from_str(e, "trustline"));
+    }
+    if before.receiver_memo != after.receiver_memo {
+        changed.push_back(String::from_str(e, "receiver_memo"));
+    }
+    if before.roles != after.roles {
+        changed.push_back(String::from_str(e, "roles"));
+    }
+    changed
 }

--- a/contracts/escrow/src/events/handler.rs
+++ b/contracts/escrow/src/events/handler.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contractevent, Address, String, Vec};
+use soroban_sdk::{contractevent, Address, BytesN, String, Vec};
 
 use crate::storage::types::{DistributionEntry, MilestoneStatusEntry};
 
@@ -42,6 +42,9 @@ pub struct EscrowUpdated {
     #[topic]
     pub engagement_id: String,
     pub admin: Address,
+    /// Names of the top-level Escrow fields whose value changed. Empty when
+    /// the update stored an escrow identical to the one it replaced.
+    pub changed_fields: Vec<String>,
 }
 
 #[contractevent(topics = ["tw_ms_change"])]
@@ -101,6 +104,11 @@ pub struct MilestonesManaged {
     pub admin: Address,
     pub added_count: u32,
     pub updated_count: u32,
+    /// Indices of the existing milestones that were updated, in call order.
+    pub updated_indices: Vec<u32>,
+    /// sha256 of each newly added milestone's description, in append order —
+    /// hashed rather than echoed to keep the event small.
+    pub added_description_hashes: Vec<BytesN<32>>,
 }
 
 #[contractevent(topics = ["tw_ttl_extend"])]

--- a/contracts/escrow/src/storage/types.rs
+++ b/contracts/escrow/src/storage/types.rs
@@ -1,10 +1,14 @@
-use soroban_sdk::{contracttype, Address, String, Vec};
+use soroban_sdk::{contracttype, Address, BytesN, String, Vec};
 
 #[contracttype]
 #[derive(Clone)]
 pub struct MilestoneStatusEntry {
     pub index: u32,
     pub status: String,
+    /// sha256 of the new evidence string, when this update carries one.
+    /// Hashed rather than echoed to keep the event small while still
+    /// letting an off-chain indexer prove which evidence was submitted.
+    pub evidence_hash: Option<BytesN<32>>,
 }
 
 #[contracttype]

--- a/contracts/escrow/src/tests/escrow.rs
+++ b/contracts/escrow/src/tests/escrow.rs
@@ -1,7 +1,8 @@
 extern crate std;
 
+use crate::events::handler::EscrowUpdated;
 use crate::storage::types::{Dispute, Escrow, Milestone, MilestoneApprovals, Roles, Trustline};
-use soroban_sdk::{testutils::Address as _, vec, Address, Env, String};
+use soroban_sdk::{testutils::Address as _, testutils::Events as _, vec, Address, Env, Event as _, String};
 
 use super::helpers::{create_escrow_contract, create_usdc_token};
 
@@ -901,4 +902,110 @@ fn test_dispute_resolver_cannot_equal_platform() {
     let client = create_escrow_contract(&env, &escrow_admin).client;
     let res = client.try_initialize_escrow(&make_escrow(distinct_resolver, distinct_platform));
     assert!(res.is_ok(), "distinct dispute_resolver and platform must succeed");
+}
+
+#[test]
+fn test_update_escrow_event_reports_changed_fields() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let escrow_admin = Address::generate(&env);
+    let approver = Address::generate(&env);
+    let service_provider = Address::generate(&env);
+    let release_signer = Address::generate(&env);
+    let dispute_resolver = Address::generate(&env);
+    let platform = Address::generate(&env);
+
+    let usdc_token = create_usdc_token(&env, &admin);
+
+    let milestones = vec![
+        &env,
+        Milestone {
+            description: String::from_str(&env, "Milestone 1"),
+            status: String::from_str(&env, "Pending"),
+            evidence: String::from_str(&env, ""),
+            approvals: MilestoneApprovals {
+                target: 1,
+                approval_count: 0,
+                approved_by: vec![&env],
+            },
+        },
+    ];
+
+    let roles = Roles {
+        approvers: vec![&env, approver.clone()],
+        service_providers: vec![&env, service_provider.clone()],
+        platform: platform.clone(),
+        release_signers: vec![&env, release_signer.clone()],
+        dispute_resolvers: vec![&env, dispute_resolver.clone()],
+        receiver: service_provider.clone(),
+        admin: escrow_admin.clone(),
+        observers: vec![&env],
+    };
+
+    let trustline = Trustline {
+        address: usdc_token.0.address.clone(),
+    };
+
+    let engagement_id = String::from_str(&env, "update_escrow_event_test");
+    let initial_escrow = Escrow {
+        engagement_id: engagement_id.clone(),
+        title: String::from_str(&env, "Original Title"),
+        description: String::from_str(&env, "Original Description"),
+        roles: roles.clone(),
+        amount: 100_000_000,
+        platform_fee: 300,
+        milestones: milestones.clone(),
+        dispute: Dispute {
+            is_disputed: false,
+            reason: String::from_str(&env, ""),
+            resolved: false,
+        },
+        released: false,
+        trustline: trustline.clone(),
+        receiver_memo: 0,
+    };
+
+    let test_data = create_escrow_contract(&env, &escrow_admin);
+    let client = test_data.client;
+    client.initialize_escrow(&initial_escrow);
+
+    // Only title and description change; everything else is passed back
+    // unchanged.
+    let updated_escrow = Escrow {
+        engagement_id: engagement_id.clone(),
+        title: String::from_str(&env, "New Title"),
+        description: String::from_str(&env, "New Description"),
+        roles: roles.clone(),
+        amount: 100_000_000,
+        platform_fee: 300,
+        milestones: milestones.clone(),
+        dispute: Dispute {
+            is_disputed: false,
+            reason: String::from_str(&env, ""),
+            resolved: false,
+        },
+        released: false,
+        trustline: trustline.clone(),
+        receiver_memo: 0,
+    };
+
+    client.update_escrow(&escrow_admin, &updated_escrow);
+
+    let expected_event = EscrowUpdated {
+        engagement_id: engagement_id.clone(),
+        admin: escrow_admin.clone(),
+        changed_fields: vec![
+            &env,
+            String::from_str(&env, "title"),
+            String::from_str(&env, "description"),
+        ],
+    };
+
+    assert_eq!(
+        env.events().all(),
+        std::vec![expected_event.to_xdr(&env, &client.address)],
+        "EscrowUpdated should report exactly the fields that changed, in field-declaration order"
+    );
 }

--- a/contracts/escrow/src/tests/milestone.rs
+++ b/contracts/escrow/src/tests/milestone.rs
@@ -1,10 +1,15 @@
 extern crate std;
 
 use crate::storage::types::{
-    Dispute, Escrow, Milestone, MilestoneApprovals, MilestoneStatusUpdate, MilestoneUpdate, Roles,
-    Trustline,
+    Dispute, Escrow, Milestone, MilestoneApprovals, MilestoneStatusEntry, MilestoneStatusUpdate,
+    MilestoneUpdate, Roles, Trustline,
 };
-use soroban_sdk::{testutils::Address as _, vec, Address, Env, String};
+use soroban_sdk::{
+    testutils::Address as _, testutils::Events as _, vec, xdr::ToXdr, Address, BytesN, Env,
+    Event as _, String,
+};
+
+use crate::events::handler::{MilestoneStatusChanged, MilestonesManaged};
 
 use super::helpers::{create_escrow_contract, create_usdc_token};
 
@@ -1386,5 +1391,226 @@ fn test_approve_milestones_unauthorized_fails_fast_before_duplicate_check() {
     assert_eq!(
         result.err(),
         Some(Ok(crate::error::MilestoneError::UnauthorizedApprover))
+    );
+}
+
+#[test]
+fn test_manage_milestones_event_carries_indices_and_hashes() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let escrow_admin = Address::generate(&env);
+    let approver = Address::generate(&env);
+    let service_provider = Address::generate(&env);
+    let platform = Address::generate(&env);
+    let release_signer = Address::generate(&env);
+    let dispute_resolver = Address::generate(&env);
+
+    let (token_client, _token_admin) = create_usdc_token(&env, &admin);
+
+    let m1_description = String::from_str(&env, "Milestone 1");
+    let initial_milestones = vec![
+        &env,
+        Milestone {
+            description: m1_description.clone(),
+            status: String::from_str(&env, "Pending"),
+            evidence: String::from_str(&env, ""),
+            approvals: MilestoneApprovals {
+                target: 1,
+                approval_count: 0,
+                approved_by: vec![&env],
+            },
+        },
+    ];
+
+    let escrow_base = Escrow {
+        engagement_id: String::from_str(&env, "manage_milestones_event_test"),
+        title: String::from_str(&env, "Test"),
+        description: String::from_str(&env, "Desc"),
+        roles: Roles {
+            approvers: vec![&env, approver.clone()],
+            service_providers: vec![&env, service_provider.clone()],
+            platform: platform.clone(),
+            release_signers: vec![&env, release_signer.clone()],
+            dispute_resolvers: vec![&env, dispute_resolver.clone()],
+            receiver: service_provider.clone(),
+            admin: escrow_admin.clone(),
+            observers: vec![&env],
+        },
+        amount: 100_000_000,
+        platform_fee: 300,
+        milestones: initial_milestones.clone(),
+        dispute: Dispute {
+            is_disputed: false,
+            reason: String::from_str(&env, ""),
+            resolved: false,
+        },
+        released: false,
+        trustline: Trustline {
+            address: token_client.address.clone(),
+        },
+        receiver_memo: 0,
+    };
+
+    let test_data = create_escrow_contract(&env, &escrow_admin);
+    let client = test_data.client;
+    client.initialize_escrow(&escrow_base);
+
+    let new_description = String::from_str(&env, "Milestone 2");
+    let to_add = vec![
+        &env,
+        Milestone {
+            description: new_description.clone(),
+            status: String::from_str(&env, "Pending"),
+            evidence: String::from_str(&env, ""),
+            approvals: MilestoneApprovals {
+                target: 1,
+                approval_count: 0,
+                approved_by: vec![&env],
+            },
+        },
+    ];
+    let updates = vec![
+        &env,
+        MilestoneUpdate {
+            index: 0,
+            new_description: Some(String::from_str(&env, "Milestone 1 updated")),
+        },
+    ];
+
+    client.manage_milestones(&escrow_admin, &to_add, &updates);
+
+    let expected_hash: BytesN<32> = env.crypto().sha256(&new_description.to_xdr(&env)).to_bytes();
+    let expected_event = MilestonesManaged {
+        engagement_id: escrow_base.engagement_id.clone(),
+        admin: escrow_admin.clone(),
+        added_count: 1,
+        updated_count: 1,
+        updated_indices: vec![&env, 0u32],
+        added_description_hashes: vec![&env, expected_hash],
+    };
+
+    assert_eq!(
+        env.events().all(),
+        std::vec![expected_event.to_xdr(&env, &client.address)],
+        "emitted MilestonesManaged event did not carry the expected indices/hashes"
+    );
+}
+
+#[test]
+fn test_change_milestone_status_event_carries_evidence_hash() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let escrow_admin = Address::generate(&env);
+    let approver = Address::generate(&env);
+    let service_provider = Address::generate(&env);
+    let platform = Address::generate(&env);
+    let release_signer = Address::generate(&env);
+    let dispute_resolver = Address::generate(&env);
+
+    let (token_client, _token_admin) = create_usdc_token(&env, &admin);
+
+    let initial_milestones = vec![
+        &env,
+        Milestone {
+            description: String::from_str(&env, "Milestone 1"),
+            status: String::from_str(&env, "in-progress"),
+            evidence: String::from_str(&env, "Initial evidence"),
+            approvals: MilestoneApprovals {
+                target: 1,
+                approval_count: 0,
+                approved_by: vec![&env],
+            },
+        },
+        Milestone {
+            description: String::from_str(&env, "Milestone 2"),
+            status: String::from_str(&env, "in-progress"),
+            evidence: String::from_str(&env, "Initial evidence"),
+            approvals: MilestoneApprovals {
+                target: 1,
+                approval_count: 0,
+                approved_by: vec![&env],
+            },
+        },
+    ];
+
+    let escrow_properties = Escrow {
+        engagement_id: String::from_str(&env, "evidence_hash_test"),
+        title: String::from_str(&env, "Test"),
+        description: String::from_str(&env, "Desc"),
+        roles: Roles {
+            approvers: vec![&env, approver.clone()],
+            service_providers: vec![&env, service_provider.clone()],
+            platform: platform.clone(),
+            release_signers: vec![&env, release_signer.clone()],
+            dispute_resolvers: vec![&env, dispute_resolver.clone()],
+            receiver: service_provider.clone(),
+            admin: escrow_admin.clone(),
+            observers: vec![&env],
+        },
+        amount: 200_000_000,
+        platform_fee: 300,
+        milestones: initial_milestones,
+        dispute: Dispute {
+            is_disputed: false,
+            reason: String::from_str(&env, ""),
+            resolved: false,
+        },
+        released: false,
+        trustline: Trustline {
+            address: token_client.address.clone(),
+        },
+        receiver_memo: 0,
+    };
+
+    let test_data = create_escrow_contract(&env, &escrow_admin);
+    let client = test_data.client;
+    client.initialize_escrow(&escrow_properties);
+
+    // One update carries new evidence, the other doesn't — the event must
+    // distinguish the two rather than hashing an absent value.
+    let new_evidence = String::from_str(&env, "Proof of delivery");
+    let updates = vec![
+        &env,
+        MilestoneStatusUpdate {
+            milestone_index: 0,
+            new_status: String::from_str(&env, "completed"),
+            new_evidence: Some(new_evidence.clone()),
+        },
+        MilestoneStatusUpdate {
+            milestone_index: 1,
+            new_status: String::from_str(&env, "completed"),
+            new_evidence: None,
+        },
+    ];
+
+    client.change_milestone_status(&updates, &service_provider);
+
+    let expected_hash: BytesN<32> = env.crypto().sha256(&new_evidence.to_xdr(&env)).to_bytes();
+    let expected_event = MilestoneStatusChanged {
+        engagement_id: escrow_properties.engagement_id.clone(),
+        service_provider: service_provider.clone(),
+        updates: vec![
+            &env,
+            MilestoneStatusEntry {
+                index: 0,
+                status: String::from_str(&env, "completed"),
+                evidence_hash: Some(expected_hash),
+            },
+            MilestoneStatusEntry {
+                index: 1,
+                status: String::from_str(&env, "completed"),
+                evidence_hash: None,
+            },
+        ],
+    };
+
+    assert_eq!(
+        env.events().all(),
+        std::vec![expected_event.to_xdr(&env, &client.address)],
+        "MilestoneStatusChanged should hash evidence when present and report None when absent"
     );
 }


### PR DESCRIPTION
Fixes #110. Companion to #115 (same fix on `multi-release-develop-v2`), adapted for this branch's `Escrow` shape.

## What was wrong

Same as #115: `EscrowUpdated`, `MilestoneStatusChanged`, and `MilestonesManaged` proved *that* something happened, not *what*.

## What changed

Same three fields as #115:
- `EscrowUpdated.changed_fields: Vec<String>`
- `MilestonesManaged.updated_indices: Vec<u32>` + `added_description_hashes: Vec<BytesN<32>>`
- `MilestoneStatusEntry.evidence_hash: Option<BytesN<32>>`

The one real difference from #115: this branch's `Escrow` carries `amount`, `dispute`, and `released` at the top level (single-release has one lump payment, not per-milestone release), so `diff_escrow_fields` compares those three additional fields alongside `title`/`description`/`platform_fee`/`milestones`/`trustline`/`receiver_memo`/`roles`. `Milestone` here has no `amount`/`dispute`/`released`/`receiver` of its own, matching this branch's simpler per-milestone shape.

## Testing

51 existing tests unaffected. Same 3 new tests as #115, adapted to this branch's struct shapes (no `new_amount` on `MilestoneUpdate` here, since amount isn't per-milestone):
- `test_update_escrow_event_reports_changed_fields`
- `test_manage_milestones_event_carries_indices_and_hashes`
- `test_change_milestone_status_event_carries_evidence_hash`

54/54 total. No new clippy warnings from the changed files.