### PR TITLE
feat(events): carry changed values in audit-trail events

### DIFF
--- a/contracts/escrow/src/contract.rs
+++ b/contracts/escrow/src/contract.rs
@@ -3,13 +3,15 @@ use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, Map, String, Sym
 use crate::core::{DisputeManager, EscrowManager, MilestoneManager};
 use crate::error::{EscrowError, MilestoneError, ReleaseError};
 use crate::events::handler::{
-    DisputeResolved, EscrowUpdated, FundEsc, FundsWithdrawn, InitEsc, MilestoneStatusChanged,
-    MilestonesApproved, MilestonesDisputed, MilestonesManaged, ReleaseEsc, TtlExtended,
+    hash_string, DisputeResolved, EscrowUpdated, FundEsc, FundsWithdrawn, InitEsc,
+    MilestoneStatusChanged, MilestonesApproved, MilestonesDisputed, MilestonesManaged, ReleaseEsc,
+    TtlExtended,
 };
 use crate::modules::math::{BasicArithmetic, BasicMath};
 use crate::storage::types::{
-    AddressBalance, DataKey, DistributionEntry, Escrow, Milestone, MilestoneStatusEntry,
-    MilestoneStatusUpdate, MilestoneUpdate,
+    AddressBalance, DataKey, DistributionEntry, Escrow, EscrowPropertyChanges, Milestone,
+    MilestoneAddedEntry, MilestoneStatusEntry, MilestoneStatusUpdate, MilestoneUpdate,
+    MilestoneUpdatedEntry,
 };
 
 #[contract]
@@ -132,11 +134,27 @@ impl EscrowContract {
         admin_address: Address,
         escrow_properties: Escrow,
     ) -> Result<Escrow, EscrowError> {
+        // Snapshot the pre-update state so the event can report exactly which
+        // mutable properties changed, rather than forcing consumers to diff a
+        // full storage snapshot themselves.
+        let previous = EscrowManager::get_escrow(e)?;
         let updated_escrow =
             EscrowManager::change_escrow_properties(e, &admin_address, escrow_properties)?;
+        let changes = EscrowPropertyChanges {
+            engagement_id: previous.engagement_id != updated_escrow.engagement_id,
+            title: previous.title != updated_escrow.title,
+            description: previous.description != updated_escrow.description,
+            platform_fee: previous.platform_fee != updated_escrow.platform_fee,
+            roles: previous.roles != updated_escrow.roles,
+            trustline: previous.trustline != updated_escrow.trustline,
+            receiver_memo: previous.receiver_memo != updated_escrow.receiver_memo,
+            old_platform_fee: previous.platform_fee,
+            new_platform_fee: updated_escrow.platform_fee,
+        };
         EscrowUpdated {
             engagement_id: updated_escrow.engagement_id.clone(),
             admin: admin_address,
+            changes,
         }
         .publish(e);
         Ok(updated_escrow)
@@ -150,13 +168,46 @@ impl EscrowContract {
     ) -> Result<Escrow, EscrowError> {
         let added_count = new_milestones.len();
         let updated_count = milestone_updates.len();
+
+        // Keep the inputs to describe in the event, then validate + apply. We
+        // only hash the free-text after the manager call succeeds, so oversized
+        // strings still return `StringTooLong` instead of trapping.
+        let added_input = new_milestones.clone();
+        let updated_input = milestone_updates.clone();
+
         let updated_escrow =
             EscrowManager::manage_milestones(e, &admin_address, new_milestones, milestone_updates)?;
+
+        // Capture the per-edit detail so the event identifies exactly what was
+        // updated, not just how many.
+        let mut updated_entries: Vec<MilestoneUpdatedEntry> = Vec::new(e);
+        for update in updated_input.iter() {
+            updated_entries.push_back(MilestoneUpdatedEntry {
+                index: update.index,
+                new_amount: update.new_amount,
+                new_description_hash: update.new_description.map(|d| hash_string(e, &d)),
+            });
+        }
+
+        // Appended milestones take the final `added_count` slots; their indices
+        // start right after the milestones that already existed.
+        let base_index = updated_escrow.milestones.len() - added_count;
+        let mut added_entries: Vec<MilestoneAddedEntry> = Vec::new(e);
+        for (offset, milestone) in added_input.iter().enumerate() {
+            added_entries.push_back(MilestoneAddedEntry {
+                index: base_index + offset as u32,
+                amount: milestone.amount,
+                description_hash: hash_string(e, &milestone.description),
+            });
+        }
+
         MilestonesManaged {
             engagement_id: updated_escrow.engagement_id.clone(),
             admin: admin_address,
             added_count,
             updated_count,
+            added: added_entries,
+            updated: updated_entries,
         }
         .publish(e);
         Ok(updated_escrow)
@@ -232,15 +283,23 @@ impl EscrowContract {
         updates: Vec<MilestoneStatusUpdate>,
         service_provider: Address,
     ) -> Result<(), MilestoneError> {
+        // Keep the inputs to describe in the event, then validate + apply. We
+        // only hash after the manager call succeeds, so an oversized evidence
+        // still returns `StringTooLong` rather than trapping in `hash_string`.
+        let described = updates.clone();
+        let escrow =
+            MilestoneManager::change_milestone_status(&e, updates, service_provider.clone())?;
+
         let mut status_entries: Vec<MilestoneStatusEntry> = Vec::new(&e);
-        for update in updates.iter() {
+        for update in described.iter() {
             status_entries.push_back(MilestoneStatusEntry {
                 index: update.milestone_index,
                 status: update.new_status.clone(),
+                // Prove which evidence was recorded (hashed to keep the event
+                // small); `None` when this update did not touch the evidence.
+                evidence_hash: update.new_evidence.map(|ev| hash_string(&e, &ev)),
             });
         }
-        let escrow =
-            MilestoneManager::change_milestone_status(&e, updates, service_provider.clone())?;
         MilestoneStatusChanged {
             engagement_id: escrow.engagement_id,
             service_provider,

--- a/contracts/escrow/src/events/handler.rs
+++ b/contracts/escrow/src/events/handler.rs
@@ -1,5 +1,28 @@
-use crate::storage::types::{DistributionEntry, MilestonePayout, MilestoneStatusEntry};
-use soroban_sdk::{contractevent, Address, String, Vec};
+use crate::storage::types::{
+    DistributionEntry, EscrowPropertyChanges, MilestoneAddedEntry, MilestonePayout,
+    MilestoneStatusEntry, MilestoneUpdatedEntry,
+};
+use soroban_sdk::{contractevent, Address, Bytes, BytesN, Env, String, Vec};
+
+/// Longest free-text field the contract accepts (evidence and description are
+/// both capped at 500 bytes by the validators). Sizing the copy buffer to this
+/// bound lets us hash any accepted string on-stack, without an allocator.
+const MAX_HASHABLE_LEN: usize = 500;
+
+/// SHA-256 of a Soroban `String`, used to prove *which* free-text content a
+/// value carried without bloating the event with the raw bytes.
+///
+/// Callers must only pass strings that have already cleared the validators'
+/// length checks (evidence and description are both bounded at
+/// `MAX_HASHABLE_LEN`); the events that use this are built after validation
+/// succeeds, so the on-stack buffer is always large enough.
+pub fn hash_string(e: &Env, value: &String) -> BytesN<32> {
+    let len = value.len() as usize;
+    let mut buf = [0u8; MAX_HASHABLE_LEN];
+    value.copy_into_slice(&mut buf[..len]);
+    let bytes = Bytes::from_slice(e, &buf[..len]);
+    e.crypto().sha256(&bytes).to_bytes()
+}
 
 #[contractevent(topics = ["tw_init"])]
 #[derive(Clone)]
@@ -35,6 +58,7 @@ pub struct EscrowUpdated {
     #[topic]
     pub engagement_id: String,
     pub admin: Address,
+    pub changes: EscrowPropertyChanges,
 }
 
 #[contractevent(topics = ["tw_ms_change"])]
@@ -96,6 +120,10 @@ pub struct MilestonesManaged {
     pub admin: Address,
     pub added_count: u32,
     pub updated_count: u32,
+    /// The milestones appended by this call (final index + key fields).
+    pub added: Vec<MilestoneAddedEntry>,
+    /// The in-place edits this call applied (index + changed fields only).
+    pub updated: Vec<MilestoneUpdatedEntry>,
 }
 
 #[contractevent(topics = ["tw_ttl_extend"])]

--- a/contracts/escrow/src/storage/types.rs
+++ b/contracts/escrow/src/storage/types.rs
@@ -1,10 +1,61 @@
-use soroban_sdk::{contracttype, Address, String, Vec};
+use soroban_sdk::{contracttype, Address, BytesN, String, Vec};
 
 #[contracttype]
 #[derive(Clone)]
 pub struct MilestoneStatusEntry {
     pub index: u32,
     pub status: String,
+    /// SHA-256 of the evidence supplied with this status change, or `None`
+    /// when the update left the evidence untouched. Hashing (instead of
+    /// echoing the raw free-text) keeps the event small while still proving
+    /// exactly which evidence content was recorded on-chain.
+    pub evidence_hash: Option<BytesN<32>>,
+}
+
+/// Which mutable escrow properties an `update_escrow` call changed.
+///
+/// The booleans let an events-only indexer see *what* changed without
+/// diffing a full storage snapshot. `platform_fee` is additionally carried
+/// as explicit before/after values because a fee change is the headline
+/// case a consumer needs to reconcile (e.g. for accounting) and the field
+/// is a small scalar, so echoing it costs almost nothing. `admin` and
+/// `platform` are intentionally absent: the contract forbids changing them.
+#[contracttype]
+#[derive(Clone)]
+pub struct EscrowPropertyChanges {
+    pub engagement_id: bool,
+    pub title: bool,
+    pub description: bool,
+    pub platform_fee: bool,
+    pub roles: bool,
+    pub trustline: bool,
+    pub receiver_memo: bool,
+    pub old_platform_fee: u32,
+    pub new_platform_fee: u32,
+}
+
+/// A milestone appended by `manage_milestones`, identified by its final
+/// index plus the key fields a consumer would want. The description is
+/// hashed to keep the event small even when many milestones are added at
+/// once.
+#[contracttype]
+#[derive(Clone)]
+pub struct MilestoneAddedEntry {
+    pub index: u32,
+    pub amount: i128,
+    pub description_hash: BytesN<32>,
+}
+
+/// An in-place milestone edit performed by `manage_milestones`. Each field
+/// is `Some` only when that property was actually changed, mirroring the
+/// optional inputs of `MilestoneUpdate`. The new description is hashed to
+/// keep the event small.
+#[contracttype]
+#[derive(Clone)]
+pub struct MilestoneUpdatedEntry {
+    pub index: u32,
+    pub new_amount: Option<i128>,
+    pub new_description_hash: Option<BytesN<32>>,
 }
 
 #[contracttype]

--- a/contracts/escrow/src/tests/events.rs
+++ b/contracts/escrow/src/tests/events.rs
@@ -1,0 +1,347 @@
+extern crate std;
+
+// Audit-trail coverage for the events that carry *what changed*, not just
+// that something changed. Each test drives an entrypoint and then asserts on
+// the concrete event payload emitted, proving an events-only indexer could
+// reconstruct the change without diffing a full storage snapshot.
+
+use crate::events::handler::{EscrowUpdated, MilestoneStatusChanged, MilestonesManaged};
+use crate::storage::types::{
+    Dispute, Escrow, EscrowPropertyChanges, Milestone, MilestoneAddedEntry, MilestoneApprovals,
+    MilestoneStatusEntry, MilestoneStatusUpdate, MilestoneUpdate, MilestoneUpdatedEntry, Roles,
+    Trustline,
+};
+use soroban_sdk::testutils::{Address as _, Events};
+use soroban_sdk::{vec, xdr, Address, Bytes, BytesN, Env, Event, String, TryFromVal};
+
+use super::helpers::{create_escrow_contract, create_usdc_token, TestData};
+
+/// SHA-256 of the given bytes, computed independently of the contract's own
+/// hashing so the tests genuinely verify the emitted hash rather than echo it.
+fn sha256(env: &Env, data: &[u8]) -> BytesN<32> {
+    env.crypto()
+        .sha256(&Bytes::from_slice(env, data))
+        .to_bytes()
+}
+
+/// XDR payload of the most recently emitted event, which for the flows tested
+/// here is always the escrow event under assertion (no token transfer runs
+/// after it).
+fn last_event_data(env: &Env) -> xdr::ScVal {
+    let all = env.events().all();
+    let raw = all.events();
+    let last = raw.last().expect("expected at least one emitted event");
+    match &last.body {
+        xdr::ContractEventBody::V0(v0) => v0.data.clone(),
+    }
+}
+
+fn last_event_topics(env: &Env) -> std::vec::Vec<xdr::ScVal> {
+    let all = env.events().all();
+    let raw = all.events();
+    let last = raw.last().expect("expected at least one emitted event");
+    match &last.body {
+        xdr::ContractEventBody::V0(v0) => v0.topics.to_vec(),
+    }
+}
+
+/// Asserts that the last emitted event serializes exactly to `expected`,
+/// covering both its topics and its full data payload.
+fn assert_last_event<E: Event>(env: &Env, expected: &E) {
+    let expected_data =
+        xdr::ScVal::try_from_val(env, &expected.data(env)).expect("event data -> ScVal");
+    assert_eq!(
+        last_event_data(env),
+        expected_data,
+        "event data payload mismatch"
+    );
+
+    let expected_topics: std::vec::Vec<xdr::ScVal> = expected
+        .topics(env)
+        .iter()
+        .map(|t| xdr::ScVal::try_from_val(env, &t).expect("topic -> ScVal"))
+        .collect();
+    assert_eq!(
+        last_event_topics(env),
+        expected_topics,
+        "event topics mismatch"
+    );
+}
+
+struct Fixture<'a> {
+    env: Env,
+    client: TestData<'a>,
+    escrow_admin: Address,
+    service_provider: Address,
+    receiver: Address,
+    engagement_id: String,
+}
+
+/// Builds and initializes an escrow with a single "in-progress" milestone,
+/// returning everything a test needs to exercise the event-emitting paths.
+fn setup(engagement: &str) -> Fixture<'static> {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let approver = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let escrow_admin = Address::generate(&env);
+    let platform = Address::generate(&env);
+    let service_provider = Address::generate(&env);
+    let release_signer = Address::generate(&env);
+    let dispute_resolver = Address::generate(&env);
+    let receiver = Address::generate(&env);
+
+    let (token_client, _) = create_usdc_token(&env, &token_admin);
+
+    let milestones = vec![
+        &env,
+        Milestone {
+            description: String::from_str(&env, "Milestone 1"),
+            status: String::from_str(&env, "in-progress"),
+            evidence: String::from_str(&env, ""),
+            approvals: MilestoneApprovals {
+                target: 1,
+                approval_count: 0,
+                approved_by: vec![&env],
+            },
+            amount: 100_000_000,
+            dispute: Dispute {
+                is_disputed: false,
+                reason: String::from_str(&env, ""),
+                resolved: false,
+            },
+            released: false,
+            receiver: receiver.clone(),
+        },
+    ];
+
+    let roles = Roles {
+        approvers: vec![&env, approver.clone()],
+        service_providers: vec![&env, service_provider.clone()],
+        platform: platform.clone(),
+        release_signers: vec![&env, release_signer.clone()],
+        dispute_resolvers: vec![&env, dispute_resolver.clone()],
+        admin: escrow_admin.clone(),
+        observers: vec![&env],
+    };
+
+    let engagement_id = String::from_str(&env, engagement);
+    let props = Escrow {
+        engagement_id: engagement_id.clone(),
+        title: String::from_str(&env, "Original Title"),
+        description: String::from_str(&env, "Original Description"),
+        roles: roles.clone(),
+        platform_fee: 300,
+        milestones: milestones.clone(),
+        trustline: Trustline {
+            address: token_client.address.clone(),
+        },
+        receiver_memo: 0,
+    };
+
+    let client = create_escrow_contract(&env, &escrow_admin);
+    client.client.initialize_escrow(&props);
+
+    Fixture {
+        env,
+        client,
+        escrow_admin,
+        service_provider,
+        receiver,
+        engagement_id,
+    }
+}
+
+#[test]
+fn milestone_status_changed_event_carries_evidence_hash() {
+    let f = setup("evt_status");
+    let env = &f.env;
+
+    let evidence = "IPFS://proof-of-completion";
+    let updates = vec![
+        env,
+        MilestoneStatusUpdate {
+            milestone_index: 0,
+            new_status: String::from_str(env, "completed"),
+            new_evidence: Some(String::from_str(env, evidence)),
+        },
+    ];
+    f.client
+        .client
+        .change_milestone_status(&updates, &f.service_provider);
+
+    let expected = MilestoneStatusChanged {
+        engagement_id: f.engagement_id.clone(),
+        service_provider: f.service_provider.clone(),
+        updates: vec![
+            env,
+            MilestoneStatusEntry {
+                index: 0,
+                status: String::from_str(env, "completed"),
+                evidence_hash: Some(sha256(env, evidence.as_bytes())),
+            },
+        ],
+    };
+    assert_last_event(env, &expected);
+}
+
+#[test]
+fn milestone_status_changed_event_omits_hash_when_evidence_unchanged() {
+    let f = setup("evt_status_noev");
+    let env = &f.env;
+
+    // No new evidence supplied -> the entry must carry `None`, distinguishing a
+    // status-only change from one that also recorded fresh evidence.
+    let updates = vec![
+        env,
+        MilestoneStatusUpdate {
+            milestone_index: 0,
+            new_status: String::from_str(env, "under-review"),
+            new_evidence: None,
+        },
+    ];
+    f.client
+        .client
+        .change_milestone_status(&updates, &f.service_provider);
+
+    let expected = MilestoneStatusChanged {
+        engagement_id: f.engagement_id.clone(),
+        service_provider: f.service_provider.clone(),
+        updates: vec![
+            env,
+            MilestoneStatusEntry {
+                index: 0,
+                status: String::from_str(env, "under-review"),
+                evidence_hash: None,
+            },
+        ],
+    };
+    assert_last_event(env, &expected);
+}
+
+#[test]
+fn oversized_evidence_still_errors_gracefully_before_hashing() {
+    // The event carries a hash of the evidence, but hashing must not run until
+    // the update has been validated — otherwise an over-long evidence string
+    // would trap in the hasher instead of returning `StringTooLong`.
+    let f = setup("evt_status_oversized");
+    let env = &f.env;
+
+    let too_long = String::from_str(env, std::str::from_utf8(&[b'a'; 501]).unwrap());
+    let updates = vec![
+        env,
+        MilestoneStatusUpdate {
+            milestone_index: 0,
+            new_status: String::from_str(env, "completed"),
+            new_evidence: Some(too_long),
+        },
+    ];
+    let result = f
+        .client
+        .client
+        .try_change_milestone_status(&updates, &f.service_provider);
+    assert_eq!(
+        result.err(),
+        Some(Ok(crate::error::MilestoneError::StringTooLong))
+    );
+}
+
+#[test]
+fn escrow_updated_event_reports_changed_properties() {
+    let f = setup("evt_update");
+    let env = &f.env;
+
+    let current = f.client.client.get_escrow();
+
+    // Change the title and platform fee before funding; leave everything else
+    // untouched so the change flags must be exactly {title, platform_fee}.
+    let mut new_props = current.clone();
+    new_props.title = String::from_str(env, "Renamed Escrow");
+    new_props.platform_fee = 500;
+
+    f.client.client.update_escrow(&f.escrow_admin, &new_props);
+
+    let expected = EscrowUpdated {
+        engagement_id: f.engagement_id.clone(),
+        admin: f.escrow_admin.clone(),
+        changes: EscrowPropertyChanges {
+            engagement_id: false,
+            title: true,
+            description: false,
+            platform_fee: true,
+            roles: false,
+            trustline: false,
+            receiver_memo: false,
+            old_platform_fee: 300,
+            new_platform_fee: 500,
+        },
+    };
+    assert_last_event(env, &expected);
+}
+
+#[test]
+fn manage_milestones_event_details_added_and_updated() {
+    let f = setup("evt_manage");
+    let env = &f.env;
+
+    // Update milestone 0's description + amount, and append one new milestone.
+    let updates = vec![
+        env,
+        MilestoneUpdate {
+            index: 0,
+            new_description: Some(String::from_str(env, "Reworded milestone")),
+            new_amount: Some(75_000_000),
+        },
+    ];
+    let added = vec![
+        env,
+        Milestone {
+            description: String::from_str(env, "Freshly added milestone"),
+            status: String::from_str(env, "Pending"),
+            evidence: String::from_str(env, ""),
+            approvals: MilestoneApprovals {
+                target: 1,
+                approval_count: 0,
+                approved_by: vec![env],
+            },
+            amount: 25_000_000,
+            dispute: Dispute {
+                is_disputed: false,
+                reason: String::from_str(env, ""),
+                resolved: false,
+            },
+            released: false,
+            receiver: f.receiver.clone(),
+        },
+    ];
+
+    f.client
+        .client
+        .manage_milestones(&f.escrow_admin, &added, &updates);
+
+    let expected = MilestonesManaged {
+        engagement_id: f.engagement_id.clone(),
+        admin: f.escrow_admin.clone(),
+        added_count: 1,
+        updated_count: 1,
+        added: vec![
+            env,
+            MilestoneAddedEntry {
+                // Appended after the single pre-existing milestone (index 0).
+                index: 1,
+                amount: 25_000_000,
+                description_hash: sha256(env, b"Freshly added milestone"),
+            },
+        ],
+        updated: vec![
+            env,
+            MilestoneUpdatedEntry {
+                index: 0,
+                new_amount: Some(75_000_000),
+                new_description_hash: Some(sha256(env, b"Reworded milestone")),
+            },
+        ],
+    };
+    assert_last_event(env, &expected);
+}

--- a/contracts/escrow/src/tests/mod.rs
+++ b/contracts/escrow/src/tests/mod.rs
@@ -4,5 +4,6 @@ mod balance;
 mod batch_atomicity;
 mod dispute;
 mod escrow;
+mod events;
 mod fund;
 mod milestone;


### PR DESCRIPTION
<p align="center"> <img src="https://github.com/user-attachments/assets/5b182044-dceb-41f5-acf0-da22dea7c98a" alt="CLR-S (2)"> </p>

# Pull Request | Trustless Work

## 1. Issue Link

- Closes #110

---

## 2. Brief Description of the Issue

Several events proved *that* something happened but not *what* changed, so an
events-only indexer could not reconstruct state and was forced to diff full
storage snapshots. This is a Repudiation (audit-trail) weakness. Concretely:

- `MilestoneStatusChanged` carried the new status but not the updated evidence.
- `EscrowUpdated` named the admin but not which properties changed, so a
  `platform_fee` change before funding was invisible in the event.
- `MilestonesManaged` reported only counts, not which milestones were
  added/updated.

This PR closes that gap **additively**: no existing event field is removed, so
current consumers keep working, and long free-text is hashed (not echoed) to
keep on-chain event payloads small.

---

## 3. Changes Made

- **`MilestoneStatusChanged`: evidence per milestone.** `MilestoneStatusEntry`
  now carries `evidence_hash: Option<BytesN<32>>` (SHA-256 of the supplied
  evidence, or `None` when the update left evidence untouched, distinguishing a
  status-only change from one that recorded fresh proof).
- **`EscrowUpdated`: what changed.** New `EscrowPropertyChanges` payload with a
  per-property changed-flag set (`engagement_id`, `title`, `description`,
  `platform_fee`, `roles`, `trustline`, `receiver_memo`) plus explicit
  before/after `platform_fee` (the headline reconciliation case, and a cheap
  scalar). `admin`/`platform` are intentionally omitted, since the contract
  forbids changing them. The diff is computed from a pre-update snapshot of
  storage.
- **`MilestonesManaged`: what was added/updated.** Keeps `added_count` and
  `updated_count` and adds `added: Vec<MilestoneAddedEntry>` (final index,
  amount, hashed description) and `updated: Vec<MilestoneUpdatedEntry>` (index
  plus only the fields that changed, description hashed).
- **`hash_string` helper** (`events/handler.rs`): allocator-free, on-stack
  SHA-256 of validator-bounded strings. Hashing runs **only after** the manager
  validates and applies the change, so oversized input still returns
  `StringTooLong` instead of trapping in the hasher.
- **Tests** (`tests/events.rs`, 5 new): reconstruct each enriched event via the
  `Event` trait and compare the emitted XDR payload + topics, using
  independently computed hashes; cover the `None`-evidence case; add a
  regression test asserting the graceful-error ordering.

---

## 4. Evidence After Solution

No behavioral UI to record, since this is an on-chain event/payload change, so
the evidence is the test suite asserting the new fields in emitted events, plus
a clean build for the deploy target.

**Full suite (all green, incl. the 5 new event tests):**

<img width="898" height="455" alt="tw2" src="https://github.com/user-attachments/assets/bf673a11-0905-4c08-9627-d5d8f018f71d" />

**Deploy-target build:**

```
$ cargo build -p escrow --target wasm32v1-none --release
    Finished `release` profile [optimized] target(s)
```

The event tests assert on the *emitted* XDR (not just storage), proving an
events-only indexer now sees the changed values.

---

## 5. Important Notes

- **Backward compatible / additive.** Existing event fields (`admin`,
  `added_count`, `updated_count`, `status`, …) are preserved; new fields are
  appended, so current consumers do not break.
- **Payload size.** Free-text (evidence, description) is hashed to 32 bytes
  rather than echoed, per the issue's guidance, keeping events small even for
  batch operations up to the 50-item cap.
- **Error semantics preserved.** Hashing is deferred until after validation, so
  over-long strings still surface as `StringTooLong` (covered by a regression
  test) rather than trapping.
- **Base branch.** Targets `multi-release-develop-v2` as noted in the issue.
  `wasm32-unknown-unknown` is rejected by this SDK version; the correct deploy
  target is `wasm32v1-none`.
- No new dependencies; `rustfmt` clean on all touched files.

Closes #110 
