### PR TITLE
chore: update soroban-sdk to 28.0.0-rc.1 for Protocol 28 (multi-release v2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,9 +233,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes-lit"
-version = "0.0.5"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0adabf37211a5276e46335feabcbb1530c95eb3fdf85f324c7db942770aa025d"
+checksum = "9b04f2b1d34cb428043f14aa4c853d14294532e8bbde3b6a3bc2faaaae31a1dd"
 dependencies = [
  "num-bigint",
  "proc-macro2",
@@ -308,6 +308,17 @@ name = "crate-git-revision"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c521bf1f43d31ed2f73441775ed31935d77901cb3451e44b38a1c1612fcbaf98"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
+name = "crate-git-revision"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54851b5b3f24621804b1cded2820975623c205e3055d2d44031cdb1237339ac8"
 dependencies = [
  "serde",
  "serde_derive",
@@ -1256,9 +1267,9 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "soroban-builtin-sdk-macros"
-version = "26.1.3"
+version = "28.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35a3a2b57b132b800e132d2c81e1818359bb2cf787ca39c61c151d6bd0798403"
+checksum = "86ffd329211a50add3965a8f4a8f70e24fc5c8268c945566ab963029b12dce40"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1268,12 +1279,12 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-common"
-version = "26.1.3"
+version = "28.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c76fad735f9622d8aa0fa0c75838d2023a659a0c57638a783b8b2eb967f7822"
+checksum = "610bb12ee937a56c2b629f8eb16efb7e47607cba4e79ab0c24132b9a53dd19a0"
 dependencies = [
  "arbitrary",
- "crate-git-revision",
+ "crate-git-revision 0.0.9",
  "ethnum",
  "num-derive",
  "num-traits",
@@ -1287,9 +1298,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-guest"
-version = "26.1.3"
+version = "28.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15aeed6d7a4dc4d3bba65e2ac92f7eeaa664900bbc82e1055e024bf637d74ed3"
+checksum = "7d383176b27bb286f718ab0ff5713bd9b01132089151266359bd9b20f38684cf"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -1297,9 +1308,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-host"
-version = "26.1.3"
+version = "28.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb523456b4efe9cdf869233cff5a2a1a5ebfae8c0acc405e57479c83781a20c"
+checksum = "36d7e5920c200939164cc58038224e2d90d7e2fabbfa505d6e2129d648dce7e2"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -1334,9 +1345,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-macros"
-version = "26.1.3"
+version = "28.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ada3449bb23c964a88a1bf633ac66ca3ebac2061693f53148b199ce816791d0"
+checksum = "077600bb175ea54592c1ac5983b8fb34ec9ab7a65f298af11d687b61e9d646a4"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1349,9 +1360,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "26.0.0"
+version = "28.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d519682f5cf750a769f2c89f32ee089f48b9e645e01af34fc3b98a78e9a4ede"
+checksum = "9e68b020e9838df2affe8488998943b81d183c7ea4990691a863b39c13d3516e"
 dependencies = [
  "serde",
  "serde_json",
@@ -1363,13 +1374,13 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "26.0.0"
+version = "28.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d03acd78bf4c80d5cacc8ee149966a49aaf8873b9936315af09f820887085c5e"
+checksum = "864a530b8a1eb07c364f3f4b2f069b737ae87df203fd290baebddb9119f2dfe5"
 dependencies = [
  "arbitrary",
  "bytes-lit",
- "crate-git-revision",
+ "crate-git-revision 0.0.9",
  "ctor",
  "derive_arbitrary",
  "ed25519-dalek",
@@ -1387,9 +1398,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "26.0.0"
+version = "28.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9751225bd51b04257eb4aca60fcc996a3b6d69c81ac39ca24e68e9bf97aabe83"
+checksum = "d66c2bfe91c8ec2179dcab5284ee99215d9271fed2eb8b9819bcd45001ac861f"
 dependencies = [
  "darling",
  "heck",
@@ -1407,9 +1418,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "26.0.0"
+version = "28.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "867c8b583180e7398af6c43134202dc1324e42c32b32d859aa921ce61de6c9ca"
+checksum = "2f20e3c44fa7939fece5c8988efa7c9e062ab5596ae7497035a2bc59ffd48816"
 dependencies = [
  "base64",
  "sha2",
@@ -1420,9 +1431,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "26.0.0"
+version = "28.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f41517bf9490f66cf0403d1048bdf1b9560c4f88b2e067b7f8ec73241b4c4514"
+checksum = "43eb9293928c35e949818f83fe5eacfe0cf45ebb32552304aaea66279b7c8403"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -1436,9 +1447,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-token-sdk"
-version = "26.0.0"
+version = "28.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a5b1a29cd4c89df533549ec18abeef644c7e4fe33f2f609b468ea14dcb00637"
+checksum = "b7053541ed1cf2cbfc78625d2b619c496c0748d20d75aee019b2f68169386f4c"
 dependencies = [
  "soroban-sdk",
 ]
@@ -1490,7 +1501,7 @@ version = "0.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee1832fb50c651ad10f734aaf5d31ca5acdfb197a6ecda64d93fcdb8885af913"
 dependencies = [
- "crate-git-revision",
+ "crate-git-revision 0.0.6",
  "data-encoding",
 ]
 
@@ -1500,21 +1511,21 @@ version = "0.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "084afcb0d458c3d5d5baa2d294b18f881e62cc258ef539d8fdf68be7dbe45520"
 dependencies = [
- "crate-git-revision",
+ "crate-git-revision 0.0.6",
  "data-encoding",
  "heapless",
 ]
 
 [[package]]
 name = "stellar-xdr"
-version = "26.0.1"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6e29c7e1f071c2767916460d006668197843d5d93f0ec8893a26f72a14f595"
+checksum = "f93d09ff8b9f919b084f664003c4c546ac66a76affd5429460dbe29f4b326f8e"
 dependencies = [
  "arbitrary",
  "base64",
  "cfg_eval",
- "crate-git-revision",
+ "crate-git-revision 0.0.9",
  "escape-bytes",
  "ethnum",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,8 @@ members = [
 ]
 
 [workspace.dependencies]
-soroban-sdk = "26.0.0"
-soroban-token-sdk = { version = "26.0.0" }
+soroban-sdk = "28.0.0-rc.1"
+soroban-token-sdk = { version = "28.0.0-rc.1" }
 
 [profile.release]
 opt-level = "z"

--- a/contracts/escrow/src/contract.rs
+++ b/contracts/escrow/src/contract.rs
@@ -1,4 +1,6 @@
-use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, Map, String, Symbol, Val, Vec};
+use soroban_sdk::{
+    contract, contractimpl, Address, BytesN, ContractExecutable, Env, Map, String, Symbol, Val, Vec,
+};
 
 use crate::core::{DisputeManager, EscrowManager, MilestoneManager};
 use crate::error::{EscrowError, MilestoneError, ReleaseError};
@@ -61,7 +63,7 @@ impl EscrowContract {
         let deployed_address = env
             .deployer()
             .with_address(deployer, salt)
-            .deploy_v2(wasm_hash, constructor_args);
+            .deploy_contract(ContractExecutable::Wasm(wasm_hash), constructor_args);
 
         let res: Val = env.invoke_contract(&deployed_address, &init_fn, init_args);
         Ok((deployed_address, res))


### PR DESCRIPTION
Updates `soroban-sdk` and `soroban-token-sdk` from 26.0.0 to 28.0.0-rc.1, the first release supporting Protocol 28. Protocol 28 goes to a mainnet vote on 16 September 2026.

Recompiling against this SDK opts the contract into CAP-86 (contract data tolerates missing or extra fields, so struct schemas can evolve without migrating stored data) and makes CAP-85 available.

## Changes

- `Cargo.toml`: both SDK dependencies moved to 28.0.0-rc.1, which pulls `soroban-env-*` 28.0.2 and `stellar-xdr` 28.0.0.
- `contract.rs`: `deploy_v2` is deprecated in this release and replaced by `deploy_contract`, which takes a `ContractExecutable`. The factory now calls `deploy_contract(ContractExecutable::Wasm(wasm_hash), constructor_args)`. Behaviour is unchanged.

Nothing else in the SDK's breaking-change list applies here: the contracts do not use `update_current_contract_wasm`, the `experimental_spec_shaking_v2` feature, `export`/`lib` arguments on `contracttype`, or the renamed `expiration_ledger` event field.

The change is deliberately kept to the minimum needed to build on Protocol 28. It does not adopt `ContractExecutable::ExternalRef` or `Env::executable_refs()`, the parts of CAP-85 that would let a fleet of deployed escrows share an upgradable code reference. That changes how the factory behaves and is worth deciding separately.

## Verification

73 tests pass. Native builds and unit tests are unaffected by the SDK upgrade.

Building to Wasm with this SDK requires `stellar-cli` 25.2.0 or newer, since spec shaking is now always on and the build system strips unreachable spec entries.

## Note for reviewers

28.0.0-rc.1 is a pre-release. Its release notes state that further breaking changes may land before the stable 28.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
