### PR TITLE
fix(roles): prevent dispute resolver from also being a milestone receiver (closes #119)

### DIFF
--- a/CONTRACT_DOCUMENTATION.md
+++ b/CONTRACT_DOCUMENTATION.md
@@ -256,7 +256,7 @@ pub enum DataKey {
 
 **Role constraints enforced at initialization:**
 - `admin` cannot overlap with `approvers`, `service_providers`, `release_signers`, or `dispute_resolvers`
-- `dispute_resolvers` cannot overlap with `approvers`, `service_providers`, `release_signers`, or `platform` (`DisputeResolverOverlapsWithOtherRole`)
+- `dispute_resolvers` cannot overlap with `approvers`, `service_providers`, `release_signers`, `platform`, or any milestone `receiver` (`DisputeResolverOverlapsWithOtherRole`)
 - No duplicate addresses within any role list
 - Each role list is capped at **5 members** maximum
 - `admin` and `platform` addresses **cannot be changed** after initialization (immutable)
@@ -831,7 +831,7 @@ APPROVALS (approve_milestones)
 
 3. **Expected-escrow check in `fund_escrow`** — The caller must supply the exact current escrow state as `expected_escrow`. If another transaction modified the escrow between the caller's read and this call, `EscrowPropertiesMismatch` is returned. This is a TOCTOU protection.
 
-4. **Role isolation** — `dispute_resolvers` cannot overlap with `approvers`, `service_providers`, `release_signers`, or `platform`. Prevents a resolver from both disputing and resolving, and (via the `platform` check) from deciding a disputed split while also collecting the platform fee.
+4. **Role isolation** — `dispute_resolvers` cannot overlap with `approvers`, `service_providers`, `release_signers`, `platform`, or milestone receivers. Prevents a resolver from acquiring dispute-opening authority (as approver, provider, signer, or receiver) while serving as resolution authority, and (via the `platform` check) from deciding a disputed split while also collecting the platform fee.
 
 5. **Admin cannot be operational** — `admin` is blocked from `approvers`, `service_providers`, `release_signers`, and `dispute_resolvers`. Admin is purely a configuration role.
 

--- a/contracts/escrow/src/core/validators/escrow.rs
+++ b/contracts/escrow/src/core/validators/escrow.rs
@@ -144,7 +144,10 @@ fn validate_role_limits(roles: &Roles) -> Result<(), EscrowError> {
 }
 
 #[inline]
-fn validate_dispute_resolver_role_overlap(roles: &Roles) -> Result<(), EscrowError> {
+fn validate_dispute_resolver_role_overlap(
+    roles: &Roles,
+    milestones: &Vec<Milestone>,
+) -> Result<(), EscrowError> {
     for resolver in roles.dispute_resolvers.iter() {
         if roles.approvers.contains(&resolver)
             || roles.service_providers.contains(&resolver)
@@ -152,6 +155,11 @@ fn validate_dispute_resolver_role_overlap(roles: &Roles) -> Result<(), EscrowErr
             || resolver == roles.platform
         {
             return Err(EscrowError::DisputeResolverOverlapsWithOtherRole);
+        }
+        for milestone in milestones.iter() {
+            if resolver == milestone.receiver {
+                return Err(EscrowError::DisputeResolverOverlapsWithOtherRole);
+            }
         }
     }
     Ok(())
@@ -187,7 +195,10 @@ pub fn validate_escrow_conditions(
         return Err(EscrowError::DisputeResolversListEmpty);
     }
     validate_role_limits(&new_escrow.roles)?;
-    validate_dispute_resolver_role_overlap(&new_escrow.roles)?;
+    validate_dispute_resolver_role_overlap(&new_escrow.roles, &new_escrow.milestones)?;
+    if let Some(existing) = existing_escrow {
+        validate_dispute_resolver_role_overlap(&new_escrow.roles, &existing.milestones)?;
+    }
 
     if is_init {
         if new_escrow.milestones.len() > 50 {
@@ -298,6 +309,13 @@ pub fn validate_manage_milestones_conditions(
             return Err(EscrowError::TooManyMilestones);
         }
         for milestone in new_milestones.iter() {
+            if existing_escrow
+                .roles
+                .dispute_resolvers
+                .contains(&milestone.receiver)
+            {
+                return Err(EscrowError::DisputeResolverOverlapsWithOtherRole);
+            }
             validate_milestone_string_lengths(&milestone)?;
             if milestone.amount <= 0 {
                 return Err(EscrowError::AmountCannotBeZero);
@@ -323,6 +341,14 @@ pub fn validate_manage_milestones_conditions(
         for update in milestone_updates.iter() {
             if update.index >= existing_escrow.milestones.len() {
                 return Err(EscrowError::InvalidMilestoneIndex);
+            }
+            let existing_m = existing_escrow.milestones.get(update.index).unwrap();
+            if existing_escrow
+                .roles
+                .dispute_resolvers
+                .contains(&existing_m.receiver)
+            {
+                return Err(EscrowError::DisputeResolverOverlapsWithOtherRole);
             }
             if let Some(ref desc) = update.new_description {
                 if desc.len() > MAX_LONG_STRING {

--- a/contracts/escrow/src/tests/dispute.rs
+++ b/contracts/escrow/src/tests/dispute.rs
@@ -1,5 +1,6 @@
 extern crate std;
 
+use crate::error::EscrowError;
 use crate::storage::types::{Dispute, Escrow, Milestone, MilestoneApprovals, Roles, Trustline};
 use soroban_sdk::{testutils::Address as _, vec, Address, Env, Map, String};
 
@@ -949,7 +950,10 @@ fn test_dispute_milestones_unauthorized_reverts() {
         &String::from_str(&env, "Dispute reason"),
     );
     assert!(
-        result.is_err(),
+        matches!(
+            result,
+            Err(Ok(EscrowError::DisputeResolverCannotDisputeTheEscrow))
+        ),
         "Dispute resolver must not be able to dispute milestones"
     );
 }
@@ -1379,3 +1383,80 @@ fn test_resolve_dispute_with_18_decimal_scale_amounts() {
     assert!(usdc_token.0.balance(&trustless_work) > 0);
     assert!(usdc_token.0.balance(&platform) > 0);
 }
+
+#[test]
+fn test_dispute_resolver_is_resolution_only_and_cannot_open_dispute() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let escrow_admin = Address::generate(&env);
+    let approver = Address::generate(&env);
+    let service_provider = Address::generate(&env);
+    let platform = Address::generate(&env);
+    let release_signer = Address::generate(&env);
+    let dispute_resolver = Address::generate(&env);
+    let receiver = Address::generate(&env);
+
+    let usdc_token = create_usdc_token(&env, &admin);
+
+    let milestones = vec![
+        &env,
+        Milestone {
+            description: String::from_str(&env, "M1"),
+            status: String::from_str(&env, "Pending"),
+            evidence: String::from_str(&env, ""),
+            approvals: MilestoneApprovals {
+                target: 1,
+                approval_count: 0,
+                approved_by: vec![&env],
+            },
+            amount: 100_000_000,
+            dispute: Dispute {
+                is_disputed: false,
+                reason: String::from_str(&env, ""),
+                resolved: false,
+            },
+            released: false,
+            receiver: receiver.clone(),
+        },
+    ];
+
+    let escrow = Escrow {
+        engagement_id: String::from_str(&env, "dispute_resolver_resolution_only"),
+        title: String::from_str(&env, "Test"),
+        description: String::from_str(&env, "Test"),
+        roles: Roles {
+            approvers: vec![&env, approver.clone()],
+            service_providers: vec![&env, service_provider.clone()],
+            platform: platform.clone(),
+            release_signers: vec![&env, release_signer.clone()],
+            dispute_resolvers: vec![&env, dispute_resolver.clone()],
+            admin: escrow_admin.clone(),
+            observers: vec![&env],
+        },
+        platform_fee: 300,
+        milestones,
+        trustline: Trustline {
+            address: usdc_token.0.address.clone(),
+        },
+        receiver_memo: 0,
+    };
+
+    let client = create_escrow_contract(&env, &escrow_admin).client;
+    client.initialize_escrow(&escrow);
+
+    // Verify runtime guard in validate_batch_milestone_dispute_conditions:
+    // Dispute resolver is strictly a resolution-only authority and is rejected before any receiver/role check
+    let res = client.try_dispute_milestones(
+        &dispute_resolver,
+        &vec![&env, 0u32],
+        &String::from_str(&env, "resolver attempted dispute"),
+    );
+    assert_eq!(
+        res,
+        Err(Ok(EscrowError::DisputeResolverCannotDisputeTheEscrow)),
+        "dispute_resolvers must be rejected by the runtime guard with DisputeResolverCannotDisputeTheEscrow"
+    );
+}
+

--- a/contracts/escrow/src/tests/escrow.rs
+++ b/contracts/escrow/src/tests/escrow.rs
@@ -1038,3 +1038,251 @@ fn test_dispute_resolver_cannot_equal_platform() {
     let res = test_data.client.try_initialize_escrow(&escrow_valid);
     assert!(res.is_ok(), "Non-overlapping platform and dispute_resolver must succeed");
 }
+
+#[test]
+fn test_dispute_resolver_cannot_equal_milestone_receiver_at_init() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let escrow_admin = Address::generate(&env);
+    let shared_address = Address::generate(&env); // will be both milestone receiver and dispute_resolver
+    let approver = Address::generate(&env);
+    let service_provider = Address::generate(&env);
+    let platform = Address::generate(&env);
+    let release_signer = Address::generate(&env);
+
+    let usdc_token = create_usdc_token(&env, &admin);
+
+    let milestone = Milestone {
+        description: String::from_str(&env, "M1"),
+        status: String::from_str(&env, "Pending"),
+        evidence: String::from_str(&env, ""),
+        approvals: MilestoneApprovals {
+            target: 1,
+            approval_count: 0,
+            approved_by: vec![&env],
+        },
+        amount: 100_000_000,
+        dispute: Dispute {
+            is_disputed: false,
+            reason: String::from_str(&env, ""),
+            resolved: false,
+        },
+        released: false,
+        receiver: shared_address.clone(),
+    };
+
+    let escrow_overlap = Escrow {
+        engagement_id: String::from_str(&env, "resolver_receiver_overlap"),
+        title: String::from_str(&env, "Test"),
+        description: String::from_str(&env, "Test"),
+        roles: Roles {
+            approvers: vec![&env, approver.clone()],
+            service_providers: vec![&env, service_provider.clone()],
+            platform: platform.clone(),
+            release_signers: vec![&env, release_signer.clone()],
+            dispute_resolvers: vec![&env, shared_address.clone()], // same as milestone.receiver
+            admin: escrow_admin.clone(),
+            observers: vec![&env],
+        },
+        platform_fee: 0,
+        milestones: vec![&env, milestone.clone()],
+        trustline: Trustline {
+            address: usdc_token.0.address.clone(),
+        },
+        receiver_memo: 0,
+    };
+
+    // dispute_resolver == milestone.receiver must fail
+    let test_data = create_escrow_contract(&env, &escrow_admin);
+    let res = test_data.client.try_initialize_escrow(&escrow_overlap);
+    assert!(
+        matches!(res, Err(Ok(EscrowError::DisputeResolverOverlapsWithOtherRole))),
+        "dispute_resolver == milestone.receiver must be rejected with DisputeResolverOverlapsWithOtherRole"
+    );
+
+    // distinct dispute_resolver and milestone.receiver must succeed
+    let distinct_dispute_resolver = Address::generate(&env);
+    let escrow_valid = Escrow {
+        engagement_id: String::from_str(&env, "resolver_receiver_distinct"),
+        title: String::from_str(&env, "Test"),
+        description: String::from_str(&env, "Test"),
+        roles: Roles {
+            approvers: vec![&env, approver.clone()],
+            service_providers: vec![&env, service_provider.clone()],
+            platform: platform.clone(),
+            release_signers: vec![&env, release_signer.clone()],
+            dispute_resolvers: vec![&env, distinct_dispute_resolver],
+            admin: escrow_admin.clone(),
+            observers: vec![&env],
+        },
+        platform_fee: 0,
+        milestones: vec![&env, milestone],
+        trustline: Trustline {
+            address: usdc_token.0.address.clone(),
+        },
+        receiver_memo: 0,
+    };
+
+    let test_data = create_escrow_contract(&env, &escrow_admin);
+    let res = test_data.client.try_initialize_escrow(&escrow_valid);
+    assert!(res.is_ok(), "Non-overlapping receiver and dispute_resolver must succeed");
+}
+
+#[test]
+fn test_dispute_resolver_cannot_equal_milestone_receiver_on_update_escrow() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let escrow_admin = Address::generate(&env);
+    let approver = Address::generate(&env);
+    let service_provider = Address::generate(&env);
+    let platform = Address::generate(&env);
+    let release_signer = Address::generate(&env);
+    let initial_dispute_resolver = Address::generate(&env);
+    let receiver = Address::generate(&env);
+
+    let usdc_token = create_usdc_token(&env, &admin);
+
+    let milestone = Milestone {
+        description: String::from_str(&env, "M1"),
+        status: String::from_str(&env, "Pending"),
+        evidence: String::from_str(&env, ""),
+        approvals: MilestoneApprovals {
+            target: 1,
+            approval_count: 0,
+            approved_by: vec![&env],
+        },
+        amount: 100_000_000,
+        dispute: Dispute {
+            is_disputed: false,
+            reason: String::from_str(&env, ""),
+            resolved: false,
+        },
+        released: false,
+        receiver: receiver.clone(),
+    };
+
+    let initial_escrow = Escrow {
+        engagement_id: String::from_str(&env, "update_overlap_test"),
+        title: String::from_str(&env, "Test"),
+        description: String::from_str(&env, "Test"),
+        roles: Roles {
+            approvers: vec![&env, approver.clone()],
+            service_providers: vec![&env, service_provider.clone()],
+            platform: platform.clone(),
+            release_signers: vec![&env, release_signer.clone()],
+            dispute_resolvers: vec![&env, initial_dispute_resolver],
+            admin: escrow_admin.clone(),
+            observers: vec![&env],
+        },
+        platform_fee: 0,
+        milestones: vec![&env, milestone.clone()],
+        trustline: Trustline {
+            address: usdc_token.0.address.clone(),
+        },
+        receiver_memo: 0,
+    };
+
+    let test_data = create_escrow_contract(&env, &escrow_admin);
+    let client = test_data.client;
+    client.initialize_escrow(&initial_escrow);
+
+    // Update dispute_resolvers to include the existing milestone's receiver (while unfunded)
+    let updated_escrow_props = Escrow {
+        engagement_id: String::from_str(&env, "update_overlap_test"),
+        title: String::from_str(&env, "Updated Title"),
+        description: String::from_str(&env, "Test"),
+        roles: Roles {
+            approvers: vec![&env, approver.clone()],
+            service_providers: vec![&env, service_provider.clone()],
+            platform: platform.clone(),
+            release_signers: vec![&env, release_signer.clone()],
+            dispute_resolvers: vec![&env, receiver.clone()], // Overlaps with milestone.receiver!
+            admin: escrow_admin.clone(),
+            observers: vec![&env],
+        },
+        platform_fee: 0,
+        milestones: vec![&env, milestone],
+        trustline: Trustline {
+            address: usdc_token.0.address.clone(),
+        },
+        receiver_memo: 0,
+    };
+
+    let res = client.try_update_escrow(&escrow_admin, &updated_escrow_props);
+    assert!(
+        matches!(res, Err(Ok(EscrowError::DisputeResolverOverlapsWithOtherRole))),
+        "Updating dispute_resolver to milestone receiver must fail with DisputeResolverOverlapsWithOtherRole"
+    );
+}
+
+#[test]
+fn test_admin_can_equal_platform() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let shared_admin_platform = Address::generate(&env); // admin == platform
+    let approver = Address::generate(&env);
+    let service_provider = Address::generate(&env);
+    let release_signer = Address::generate(&env);
+    let dispute_resolver = Address::generate(&env);
+    let receiver = Address::generate(&env);
+
+    let usdc_token = create_usdc_token(&env, &admin);
+
+    let milestone = Milestone {
+        description: String::from_str(&env, "M1"),
+        status: String::from_str(&env, "Pending"),
+        evidence: String::from_str(&env, ""),
+        approvals: MilestoneApprovals {
+            target: 1,
+            approval_count: 0,
+            approved_by: vec![&env],
+        },
+        amount: 100_000_000,
+        dispute: Dispute {
+            is_disputed: false,
+            reason: String::from_str(&env, ""),
+            resolved: false,
+        },
+        released: false,
+        receiver: receiver.clone(),
+    };
+
+    let escrow = Escrow {
+        engagement_id: String::from_str(&env, "admin_eq_platform"),
+        title: String::from_str(&env, "Test Admin Eq Platform"),
+        description: String::from_str(&env, "Test"),
+        roles: Roles {
+            approvers: vec![&env, approver.clone()],
+            service_providers: vec![&env, service_provider.clone()],
+            platform: shared_admin_platform.clone(), // admin == platform
+            release_signers: vec![&env, release_signer.clone()],
+            dispute_resolvers: vec![&env, dispute_resolver.clone()],
+            admin: shared_admin_platform.clone(),    // admin == platform
+            observers: vec![&env],
+        },
+        platform_fee: 300,
+        milestones: vec![&env, milestone.clone()],
+        trustline: Trustline {
+            address: usdc_token.0.address.clone(),
+        },
+        receiver_memo: 0,
+    };
+
+    let test_data = create_escrow_contract(&env, &shared_admin_platform);
+    let client = test_data.client;
+    let res = client.try_initialize_escrow(&escrow);
+    assert!(res.is_ok(), "admin == platform must be permitted at initialization");
+
+    // Also verify updating escrow when admin == platform
+    let mut updated_escrow = escrow.clone();
+    updated_escrow.title = String::from_str(&env, "Updated Title Admin Eq Platform");
+    let update_res = client.try_update_escrow(&shared_admin_platform, &updated_escrow);
+    assert!(update_res.is_ok(), "admin == platform must remain permitted on update");
+}
+

--- a/contracts/escrow/src/tests/milestone.rs
+++ b/contracts/escrow/src/tests/milestone.rs
@@ -1,5 +1,6 @@
 extern crate std;
 
+use crate::error::EscrowError;
 use crate::storage::types::{
     Dispute, Escrow, Milestone, MilestoneApprovals, MilestoneStatusUpdate, MilestoneUpdate, Roles,
     Trustline,
@@ -1704,3 +1705,124 @@ fn test_manage_milestones_rejects_non_positive_amount_update() {
     // Original amount unchanged.
     assert_eq!(client.get_escrow().milestones.get(0).unwrap().amount, 50_000_000);
 }
+
+#[test]
+fn test_dispute_resolver_cannot_equal_milestone_receiver_on_milestone_addition() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let escrow_admin = Address::generate(&env);
+    let approver = Address::generate(&env);
+    let service_provider = Address::generate(&env);
+    let platform = Address::generate(&env);
+    let release_signer = Address::generate(&env);
+    let dispute_resolver = Address::generate(&env);
+    let initial_receiver = Address::generate(&env);
+
+    let (token_client, _token_admin) = create_usdc_token(&env, &admin);
+
+    let initial_milestones = vec![
+        &env,
+        Milestone {
+            description: String::from_str(&env, "M1"),
+            status: String::from_str(&env, "Pending"),
+            evidence: String::from_str(&env, ""),
+            approvals: MilestoneApprovals {
+                target: 1,
+                approval_count: 0,
+                approved_by: vec![&env],
+            },
+            amount: 50_000_000,
+            dispute: Dispute {
+                is_disputed: false,
+                reason: String::from_str(&env, ""),
+                resolved: false,
+            },
+            released: false,
+            receiver: initial_receiver,
+        },
+    ];
+
+    let escrow = Escrow {
+        engagement_id: String::from_str(&env, "add_milestone_resolver_overlap"),
+        title: String::from_str(&env, "Test"),
+        description: String::from_str(&env, "Test"),
+        roles: Roles {
+            approvers: vec![&env, approver.clone()],
+            service_providers: vec![&env, service_provider.clone()],
+            platform: platform.clone(),
+            release_signers: vec![&env, release_signer.clone()],
+            dispute_resolvers: vec![&env, dispute_resolver.clone()],
+            admin: escrow_admin.clone(),
+            observers: vec![&env],
+        },
+        platform_fee: 300,
+        milestones: initial_milestones,
+        trustline: Trustline {
+            address: token_client.address.clone(),
+        },
+        receiver_memo: 0,
+    };
+
+    let client = create_escrow_contract(&env, &escrow_admin).client;
+    client.initialize_escrow(&escrow);
+
+    // Attempt to add a milestone whose receiver is the dispute resolver
+    let invalid_milestones = vec![
+        &env,
+        Milestone {
+            description: String::from_str(&env, "M2-invalid"),
+            status: String::from_str(&env, "Pending"),
+            evidence: String::from_str(&env, ""),
+            approvals: MilestoneApprovals {
+                target: 1,
+                approval_count: 0,
+                approved_by: vec![&env],
+            },
+            amount: 50_000_000,
+            dispute: Dispute {
+                is_disputed: false,
+                reason: String::from_str(&env, ""),
+                resolved: false,
+            },
+            released: false,
+            receiver: dispute_resolver.clone(), // Overlaps with dispute_resolver!
+        },
+    ];
+
+    let res = client.try_manage_milestones(&escrow_admin, &invalid_milestones, &vec![&env]);
+    assert!(
+        matches!(res, Err(Ok(EscrowError::DisputeResolverOverlapsWithOtherRole))),
+        "Adding milestone where receiver equals dispute_resolver must fail with DisputeResolverOverlapsWithOtherRole"
+    );
+
+    // Adding milestone with a distinct, non-overlapping receiver must succeed
+    let distinct_receiver = Address::generate(&env);
+    let valid_milestones = vec![
+        &env,
+        Milestone {
+            description: String::from_str(&env, "M2-valid"),
+            status: String::from_str(&env, "Pending"),
+            evidence: String::from_str(&env, ""),
+            approvals: MilestoneApprovals {
+                target: 1,
+                approval_count: 0,
+                approved_by: vec![&env],
+            },
+            amount: 50_000_000,
+            dispute: Dispute {
+                is_disputed: false,
+                reason: String::from_str(&env, ""),
+                resolved: false,
+            },
+            released: false,
+            receiver: distinct_receiver,
+        },
+    ];
+
+    let res = client.try_manage_milestones(&escrow_admin, &valid_milestones, &vec![&env]);
+    assert!(res.is_ok(), "Adding milestone with valid distinct receiver must succeed");
+    assert_eq!(client.get_escrow().milestones.len(), 2);
+}
+


### PR DESCRIPTION
## Description
Closes #119.

This PR enforces the product invariant that in Multi Release v2, dispute resolvers are strictly resolution-only authorities and must not be able to acquire dispute-opening authority by also being assigned as a milestone receiver.

### Key Changes
1. **Escrow Initialization & Property Updates**:
   - Updated `validate_dispute_resolver_role_overlap` in `contracts/escrow/src/core/validators/escrow.rs` to take `milestones: &Vec<Milestone>` and reject any configuration where an address in `roles.dispute_resolvers` equals any milestone's `receiver`.
   - Returns `EscrowError::DisputeResolverOverlapsWithOtherRole`.
   - In `validate_escrow_conditions`, validated `new_escrow.roles` against both `new_escrow.milestones` and, during property updates, `existing_escrow.milestones`.
2. **Milestone Management (`manage_milestones`)**:
   - In `validate_manage_milestones_conditions`, verified that newly appended milestones (`new_milestones`) cannot have a `receiver` that belongs to `existing_escrow.roles.dispute_resolvers`.
   - Added defensive validation ensuring updated milestones do not point to dispute resolvers.
3. **Runtime Guard Preservation**:
   - Preserved the existing runtime guard in `validate_batch_milestone_dispute_conditions` where dispute resolvers are rejected immediately with `EscrowError::DisputeResolverCannotDisputeTheEscrow` before reaching any role or receiver checks.
4. **Permitted Role Invariants**:
   - Verified that `admin == platform` remains completely valid (the distinction is field/capability based, not an address-separation invariant).
5. **Documentation**:
   - Updated `CONTRACT_DOCUMENTATION.md` under role constraints and role isolation sections.

### Test Coverage Added
- `test_dispute_resolver_cannot_equal_milestone_receiver_at_init`: Verifies rejection at initialization with `DisputeResolverOverlapsWithOtherRole` and success with distinct addresses.
- `test_dispute_resolver_cannot_equal_milestone_receiver_on_update_escrow`: Verifies that updating `dispute_resolvers` on an unfunded escrow to match an existing milestone receiver is rejected.
- `test_admin_can_equal_platform`: Explicitly validates that `admin == platform` succeeds during initialization and property updates.
- `test_dispute_resolver_cannot_equal_milestone_receiver_on_milestone_addition`: Verifies rejection when attempting to append a milestone whose receiver matches a dispute resolver.
- `test_dispute_resolver_is_resolution_only_and_cannot_open_dispute`: Verifies the runtime dispute guard that blocks dispute resolvers from opening disputes with `DisputeResolverCannotDisputeTheEscrow`.

### Verification
- Tested full test suite twice: **78 passed, 0 failed, 0 warnings on modified files**.
- Checked with `cargo clippy --all-targets`.
