### PR TITLE
fix: reject dispute resolver as milestone receiver in multi-release v2

### DIFF
--- a/contracts/escrow/src/core/validators/escrow.rs
+++ b/contracts/escrow/src/core/validators/escrow.rs
@@ -144,12 +144,18 @@ fn validate_role_limits(roles: &Roles) -> Result<(), EscrowError> {
 }
 
 #[inline]
-fn validate_dispute_resolver_role_overlap(roles: &Roles) -> Result<(), EscrowError> {
+fn validate_dispute_resolver_role_overlap(
+    roles: &Roles,
+    milestones: &Vec<Milestone>,
+) -> Result<(), EscrowError> {
     for resolver in roles.dispute_resolvers.iter() {
+        // A milestone receiver may open a dispute, so a resolver must never be
+        // one. Single-release enforces the same through `roles.receiver`.
         if roles.approvers.contains(&resolver)
             || roles.service_providers.contains(&resolver)
             || roles.release_signers.contains(&resolver)
             || resolver == roles.platform
+            || milestones.iter().any(|m| m.receiver == resolver)
         {
             return Err(EscrowError::DisputeResolverOverlapsWithOtherRole);
         }
@@ -187,7 +193,7 @@ pub fn validate_escrow_conditions(
         return Err(EscrowError::DisputeResolversListEmpty);
     }
     validate_role_limits(&new_escrow.roles)?;
-    validate_dispute_resolver_role_overlap(&new_escrow.roles)?;
+    validate_dispute_resolver_role_overlap(&new_escrow.roles, &new_escrow.milestones)?;
 
     if is_init {
         if new_escrow.milestones.len() > 50 {
@@ -313,6 +319,13 @@ pub fn validate_manage_milestones_conditions(
             }
             if milestone.approvals.target > existing_escrow.roles.approvers.len() {
                 return Err(EscrowError::TargetExceedsApprovers);
+            }
+            if existing_escrow
+                .roles
+                .dispute_resolvers
+                .contains(&milestone.receiver)
+            {
+                return Err(EscrowError::DisputeResolverOverlapsWithOtherRole);
             }
         }
     }

--- a/contracts/escrow/src/tests/escrow.rs
+++ b/contracts/escrow/src/tests/escrow.rs
@@ -1038,3 +1038,141 @@ fn test_dispute_resolver_cannot_equal_platform() {
     let res = test_data.client.try_initialize_escrow(&escrow_valid);
     assert!(res.is_ok(), "Non-overlapping platform and dispute_resolver must succeed");
 }
+
+/// A dispute resolver is a resolution-only authority. A milestone receiver may
+/// open a dispute, so the two must never share an address — otherwise a
+/// resolver would acquire dispute-opening authority through the receiver role.
+/// Single-release enforces the same invariant through `roles.receiver`.
+#[test]
+fn test_dispute_resolver_cannot_be_milestone_receiver() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let escrow_admin = Address::generate(&env);
+    let platform = Address::generate(&env);
+    let dispute_resolver = Address::generate(&env);
+
+    let usdc_token = create_usdc_token(&env, &admin);
+
+    let make_escrow = |receiver: Address| Escrow {
+        engagement_id: String::from_str(&env, "resolver_receiver_overlap"),
+        title: String::from_str(&env, "Test"),
+        description: String::from_str(&env, "Test"),
+        roles: Roles {
+            approvers: vec![&env, Address::generate(&env)],
+            service_providers: vec![&env, Address::generate(&env)],
+            platform: platform.clone(),
+            release_signers: vec![&env, Address::generate(&env)],
+            dispute_resolvers: vec![&env, dispute_resolver.clone()],
+            admin: escrow_admin.clone(),
+            observers: vec![&env],
+        },
+        platform_fee: 0,
+        milestones: vec![
+            &env,
+            Milestone {
+                description: String::from_str(&env, "M1"),
+                status: String::from_str(&env, "Pending"),
+                evidence: String::from_str(&env, ""),
+                approvals: MilestoneApprovals {
+                    target: 1,
+                    approval_count: 0,
+                    approved_by: vec![&env],
+                },
+                amount: 100_000_000,
+                dispute: Dispute {
+                    is_disputed: false,
+                    reason: String::from_str(&env, ""),
+                    resolved: false,
+                },
+                released: false,
+                receiver,
+            },
+        ],
+        trustline: Trustline {
+            address: usdc_token.0.address.clone(),
+        },
+        receiver_memo: 0,
+    };
+
+    // dispute_resolver == milestone.receiver must be rejected at initialization.
+    let test_data = create_escrow_contract(&env, &escrow_admin);
+    let res = test_data
+        .client
+        .try_initialize_escrow(&make_escrow(dispute_resolver.clone()));
+    assert!(
+        matches!(
+            res,
+            Err(Ok(EscrowError::DisputeResolverOverlapsWithOtherRole))
+        ),
+        "dispute_resolver as milestone receiver must be rejected"
+    );
+
+    // A distinct receiver keeps the configuration valid.
+    let test_data = create_escrow_contract(&env, &escrow_admin);
+    let res = test_data
+        .client
+        .try_initialize_escrow(&make_escrow(Address::generate(&env)));
+    assert!(
+        res.is_ok(),
+        "a receiver distinct from every dispute_resolver must be accepted"
+    );
+}
+
+/// `admin` and `platform` are a capability distinction, not an address-separation
+/// invariant, so sharing one address between them stays valid.
+#[test]
+fn test_admin_can_equal_platform() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let shared = Address::generate(&env); // both admin and platform
+    let usdc_token = create_usdc_token(&env, &admin);
+
+    let escrow = Escrow {
+        engagement_id: String::from_str(&env, "admin_eq_platform"),
+        title: String::from_str(&env, "Test"),
+        description: String::from_str(&env, "Test"),
+        roles: Roles {
+            approvers: vec![&env, Address::generate(&env)],
+            service_providers: vec![&env, Address::generate(&env)],
+            platform: shared.clone(),
+            release_signers: vec![&env, Address::generate(&env)],
+            dispute_resolvers: vec![&env, Address::generate(&env)],
+            admin: shared.clone(),
+            observers: vec![&env],
+        },
+        platform_fee: 0,
+        milestones: vec![
+            &env,
+            Milestone {
+                description: String::from_str(&env, "M1"),
+                status: String::from_str(&env, "Pending"),
+                evidence: String::from_str(&env, ""),
+                approvals: MilestoneApprovals {
+                    target: 1,
+                    approval_count: 0,
+                    approved_by: vec![&env],
+                },
+                amount: 100_000_000,
+                dispute: Dispute {
+                    is_disputed: false,
+                    reason: String::from_str(&env, ""),
+                    resolved: false,
+                },
+                released: false,
+                receiver: Address::generate(&env),
+            },
+        ],
+        trustline: Trustline {
+            address: usdc_token.0.address.clone(),
+        },
+        receiver_memo: 0,
+    };
+
+    let test_data = create_escrow_contract(&env, &shared);
+    let res = test_data.client.try_initialize_escrow(&escrow);
+    assert!(res.is_ok(), "admin == platform must remain valid");
+}

--- a/contracts/escrow/src/tests/milestone.rs
+++ b/contracts/escrow/src/tests/milestone.rs
@@ -1,5 +1,6 @@
 extern crate std;
 
+use crate::error::EscrowError;
 use crate::storage::types::{
     Dispute, Escrow, Milestone, MilestoneApprovals, MilestoneStatusUpdate, MilestoneUpdate, Roles,
     Trustline,
@@ -1703,4 +1704,96 @@ fn test_manage_milestones_rejects_non_positive_amount_update() {
 
     // Original amount unchanged.
     assert_eq!(client.get_escrow().milestones.get(0).unwrap().amount, 50_000_000);
+}
+
+/// The resolver/receiver invariant must also hold for milestones introduced
+/// after initialization, not only for the ones supplied at init.
+#[test]
+fn test_manage_milestones_rejects_dispute_resolver_as_receiver() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let escrow_admin = Address::generate(&env);
+    let dispute_resolver = Address::generate(&env);
+
+    let (token_client, _) = create_usdc_token(&env, &admin);
+
+    let escrow_properties = Escrow {
+        engagement_id: String::from_str(&env, "late-milestone-resolver"),
+        title: String::from_str(&env, "Deferred Milestones Escrow"),
+        description: String::from_str(&env, "Init without milestones, add later"),
+        roles: Roles {
+            approvers: vec![&env, Address::generate(&env)],
+            service_providers: vec![&env, Address::generate(&env)],
+            platform: Address::generate(&env),
+            release_signers: vec![&env, Address::generate(&env)],
+            dispute_resolvers: vec![&env, dispute_resolver.clone()],
+            admin: escrow_admin.clone(),
+            observers: vec![&env],
+        },
+        platform_fee: 0,
+        milestones: vec![&env],
+        trustline: Trustline {
+            address: token_client.address.clone(),
+        },
+        receiver_memo: 0,
+    };
+
+    let test_data = create_escrow_contract(&env, &escrow_admin);
+    let client = test_data.client;
+    client.initialize_escrow(&escrow_properties);
+
+    let milestone_for = |receiver: Address| {
+        vec![
+            &env,
+            Milestone {
+                description: String::from_str(&env, "Late milestone"),
+                status: String::from_str(&env, "Pending"),
+                evidence: String::from_str(&env, ""),
+                approvals: MilestoneApprovals {
+                    target: 1,
+                    approval_count: 0,
+                    approved_by: vec![&env],
+                },
+                amount: 100_000_000,
+                dispute: Dispute {
+                    is_disputed: false,
+                    reason: String::from_str(&env, ""),
+                    resolved: false,
+                },
+                released: false,
+                receiver,
+            },
+        ]
+    };
+    let no_updates = vec![&env];
+
+    // A milestone paying a dispute resolver must be rejected.
+    let result = client.try_manage_milestones(
+        &escrow_admin,
+        &milestone_for(dispute_resolver.clone()),
+        &no_updates,
+    );
+    assert!(
+        matches!(
+            result,
+            Err(Ok(EscrowError::DisputeResolverOverlapsWithOtherRole))
+        ),
+        "adding a milestone whose receiver is a dispute_resolver must be rejected"
+    );
+    assert_eq!(
+        client.get_escrow().milestones.len(),
+        0,
+        "the rejected milestone must not be stored"
+    );
+
+    // Any other receiver is still accepted.
+    let result = client.try_manage_milestones(
+        &escrow_admin,
+        &milestone_for(Address::generate(&env)),
+        &no_updates,
+    );
+    assert!(result.is_ok(), "a non-resolver receiver must be accepted");
+    assert_eq!(client.get_escrow().milestones.len(), 1);
 }


### PR DESCRIPTION
Closes #119.

Multi Release v2 rejected dispute resolvers overlapping `approvers`, `service_providers`, `release_signers` and `platform`, but not milestone receivers. Since a milestone receiver may open a dispute, that gap let a resolver acquire dispute-opening authority through the receiver role, and it diverged from Single Release v2, which already rejects the overlap through `roles.receiver`.

The runtime guard in `validate_batch_milestone_dispute_conditions` already stopped such an address from actually opening a dispute, so this is about rejecting the inconsistent configuration up front rather than fixing an exploitable path.

## Changes

`validate_dispute_resolver_role_overlap` now takes the milestone list and rejects any resolver that is also a milestone receiver. It is called before the init/update split, so the invariant covers both `initialize_escrow` and `update_escrow`.

`validate_manage_milestones_conditions` applies the same check to milestones appended later. `MilestoneUpdate` only carries a description and an amount, so an update cannot introduce a receiver and needs no equivalent check.

The existing runtime guard is untouched.

## Tests

76 pass, three of them new:

- `test_dispute_resolver_cannot_be_milestone_receiver` covers rejection at initialization and that a distinct receiver is still accepted.
- `test_manage_milestones_rejects_dispute_resolver_as_receiver` covers a milestone added after initialization, and asserts the rejected milestone is not stored.
- `test_admin_can_equal_platform` pins that `admin == platform` stays valid, since that pair is a capability distinction rather than an address-separation invariant.

Both invariant tests fail without the validation change. Existing overlap tests and the dispute-execution guard test pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
