### PR TITLE
fix: reject admin as milestone receiver in multi-release v2

### DIFF
--- a/contracts/escrow/src/core/validators/escrow.rs
+++ b/contracts/escrow/src/core/validators/escrow.rs
@@ -98,11 +98,17 @@ pub fn validate_release_milestones_conditions(
 }
 
 #[inline]
-fn validate_admin_role_overlap(roles: &Roles) -> Result<(), EscrowError> {
+fn validate_admin_role_overlap(
+    roles: &Roles,
+    milestones: &Vec<Milestone>,
+) -> Result<(), EscrowError> {
+    // The admin must not be a payee. Single-release enforces the same through
+    // `roles.receiver`; here the receivers live on the milestones.
     if roles.approvers.contains(&roles.admin)
         || roles.service_providers.contains(&roles.admin)
         || roles.release_signers.contains(&roles.admin)
         || roles.dispute_resolvers.contains(&roles.admin)
+        || milestones.iter().any(|m| m.receiver == roles.admin)
     {
         return Err(EscrowError::AdminAddressOverlapsWithOtherRole);
     }
@@ -227,7 +233,7 @@ pub fn validate_escrow_conditions(
                 return Err(EscrowError::TargetExceedsApprovers);
             }
         }
-        validate_admin_role_overlap(&new_escrow.roles)?;
+        validate_admin_role_overlap(&new_escrow.roles, &new_escrow.milestones)?;
     } else {
         let existing = existing_escrow.ok_or(EscrowError::EscrowNotFound)?;
         let caller = admin.ok_or(EscrowError::OnlyAdminAddressExecuteThisFunction)?;
@@ -260,7 +266,7 @@ pub fn validate_escrow_conditions(
                 return Err(EscrowError::EscrowPropertiesMismatch);
             }
         }
-        validate_admin_role_overlap(&new_escrow.roles)?;
+        validate_admin_role_overlap(&new_escrow.roles, &new_escrow.milestones)?;
     }
 
     Ok(())
@@ -326,6 +332,9 @@ pub fn validate_manage_milestones_conditions(
                 .contains(&milestone.receiver)
             {
                 return Err(EscrowError::DisputeResolverOverlapsWithOtherRole);
+            }
+            if milestone.receiver == existing_escrow.roles.admin {
+                return Err(EscrowError::AdminAddressOverlapsWithOtherRole);
             }
         }
     }

--- a/contracts/escrow/src/tests/escrow.rs
+++ b/contracts/escrow/src/tests/escrow.rs
@@ -1176,3 +1176,78 @@ fn test_admin_can_equal_platform() {
     let res = test_data.client.try_initialize_escrow(&escrow);
     assert!(res.is_ok(), "admin == platform must remain valid");
 }
+
+/// The admin must not be a payee. Single-release enforces this through
+/// `roles.receiver`; in multi-release the receivers live on the milestones, so
+/// the same rule has to be checked against every milestone.
+#[test]
+fn test_admin_cannot_be_milestone_receiver() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let escrow_admin = Address::generate(&env);
+
+    let usdc_token = create_usdc_token(&env, &admin);
+
+    let make_escrow = |receiver: Address| Escrow {
+        engagement_id: String::from_str(&env, "admin_receiver_overlap"),
+        title: String::from_str(&env, "Test"),
+        description: String::from_str(&env, "Test"),
+        roles: Roles {
+            approvers: vec![&env, Address::generate(&env)],
+            service_providers: vec![&env, Address::generate(&env)],
+            platform: Address::generate(&env),
+            release_signers: vec![&env, Address::generate(&env)],
+            dispute_resolvers: vec![&env, Address::generate(&env)],
+            admin: escrow_admin.clone(),
+            observers: vec![&env],
+        },
+        platform_fee: 0,
+        milestones: vec![
+            &env,
+            Milestone {
+                description: String::from_str(&env, "M1"),
+                status: String::from_str(&env, "Pending"),
+                evidence: String::from_str(&env, ""),
+                approvals: MilestoneApprovals {
+                    target: 1,
+                    approval_count: 0,
+                    approved_by: vec![&env],
+                },
+                amount: 100_000_000,
+                dispute: Dispute {
+                    is_disputed: false,
+                    reason: String::from_str(&env, ""),
+                    resolved: false,
+                },
+                released: false,
+                receiver,
+            },
+        ],
+        trustline: Trustline {
+            address: usdc_token.0.address.clone(),
+        },
+        receiver_memo: 0,
+    };
+
+    // admin == milestone.receiver must be rejected at initialization.
+    let test_data = create_escrow_contract(&env, &escrow_admin);
+    let res = test_data
+        .client
+        .try_initialize_escrow(&make_escrow(escrow_admin.clone()));
+    assert!(
+        matches!(res, Err(Ok(EscrowError::AdminAddressOverlapsWithOtherRole))),
+        "admin as milestone receiver must be rejected"
+    );
+
+    // A distinct receiver keeps the configuration valid.
+    let test_data = create_escrow_contract(&env, &escrow_admin);
+    let res = test_data
+        .client
+        .try_initialize_escrow(&make_escrow(Address::generate(&env)));
+    assert!(
+        res.is_ok(),
+        "a receiver distinct from the admin must be accepted"
+    );
+}

--- a/contracts/escrow/src/tests/milestone.rs
+++ b/contracts/escrow/src/tests/milestone.rs
@@ -1797,3 +1797,94 @@ fn test_manage_milestones_rejects_dispute_resolver_as_receiver() {
     assert!(result.is_ok(), "a non-resolver receiver must be accepted");
     assert_eq!(client.get_escrow().milestones.len(), 1);
 }
+
+/// The admin/receiver invariant must also hold for milestones introduced after
+/// initialization.
+#[test]
+fn test_manage_milestones_rejects_admin_as_receiver() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let escrow_admin = Address::generate(&env);
+
+    let (token_client, _) = create_usdc_token(&env, &admin);
+
+    let escrow_properties = Escrow {
+        engagement_id: String::from_str(&env, "late-milestone-admin"),
+        title: String::from_str(&env, "Deferred Milestones Escrow"),
+        description: String::from_str(&env, "Init without milestones, add later"),
+        roles: Roles {
+            approvers: vec![&env, Address::generate(&env)],
+            service_providers: vec![&env, Address::generate(&env)],
+            platform: Address::generate(&env),
+            release_signers: vec![&env, Address::generate(&env)],
+            dispute_resolvers: vec![&env, Address::generate(&env)],
+            admin: escrow_admin.clone(),
+            observers: vec![&env],
+        },
+        platform_fee: 0,
+        milestones: vec![&env],
+        trustline: Trustline {
+            address: token_client.address.clone(),
+        },
+        receiver_memo: 0,
+    };
+
+    let test_data = create_escrow_contract(&env, &escrow_admin);
+    let client = test_data.client;
+    client.initialize_escrow(&escrow_properties);
+
+    let milestone_for = |receiver: Address| {
+        vec![
+            &env,
+            Milestone {
+                description: String::from_str(&env, "Late milestone"),
+                status: String::from_str(&env, "Pending"),
+                evidence: String::from_str(&env, ""),
+                approvals: MilestoneApprovals {
+                    target: 1,
+                    approval_count: 0,
+                    approved_by: vec![&env],
+                },
+                amount: 100_000_000,
+                dispute: Dispute {
+                    is_disputed: false,
+                    reason: String::from_str(&env, ""),
+                    resolved: false,
+                },
+                released: false,
+                receiver,
+            },
+        ]
+    };
+    let no_updates = vec![&env];
+
+    // A milestone paying the admin must be rejected.
+    let result = client.try_manage_milestones(
+        &escrow_admin,
+        &milestone_for(escrow_admin.clone()),
+        &no_updates,
+    );
+    assert!(
+        matches!(
+            result,
+            Err(Ok(EscrowError::AdminAddressOverlapsWithOtherRole))
+        ),
+        "adding a milestone whose receiver is the admin must be rejected"
+    );
+    assert_eq!(
+        client.get_escrow().milestones.len(),
+        0,
+        "the rejected milestone must not be stored"
+    );
+
+    // Any other receiver is still accepted.
+    let result = client.try_manage_milestones(
+        &escrow_admin,
+        &milestone_for(Address::generate(&env)),
+        &no_updates,
+    );
+    assert!(result.is_ok(), "a non-admin receiver must be accepted");
+    assert_eq!(client.get_escrow().milestones.len(), 1);
+}


### PR DESCRIPTION
Closes #127.

Aligns Multi Release v2 with Single Release v2 on the admin/receiver invariant. Single Release already rejected `admin == roles.receiver`; Multi Release had no equivalent rule because its receivers live on each milestone rather than in `Roles`, so a configuration paying the admin through a milestone was accepted.

The decision on #127 was to enforce the restriction rather than drop it from Single Release, so both variants now state the same rule: the admin must not be a payee.

## Changes

`validate_admin_role_overlap` now takes the milestone list and rejects an admin that is also a milestone receiver, returning `AdminAddressOverlapsWithOtherRole`. Both call sites pass the milestones, so the rule covers initialization and updates.

`validate_manage_milestones_conditions` applies the same check to milestones appended later, next to the equivalent dispute-resolver check added in #119. `MilestoneUpdate` carries only a description and an amount, so an update cannot introduce a receiver.

`admin == platform` is untouched and remains valid.

## Tests

78 pass, two of them new:

- `test_admin_cannot_be_milestone_receiver` covers rejection at initialization and that a distinct receiver is still accepted.
- `test_manage_milestones_rejects_admin_as_receiver` covers a milestone added after initialization, and asserts the rejected milestone is not stored.

Both fail without the validation change. `test_admin_can_equal_platform` and the existing admin and dispute-resolver overlap tests pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
